### PR TITLE
Clean up how a ChannelFactory is constructed

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1ServerChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1ServerChannelFactory.scala
@@ -1,16 +1,14 @@
 package org.http4s.blaze.channel.nio1
 
 import java.nio.channels._
-import scala.annotation.tailrec
 import java.net.SocketAddress
+
 import org.http4s.blaze.channel._
+
 import scala.util.control.NonFatal
-import org.log4s.getLogger
 
 abstract class NIO1ServerChannelFactory[Channel <: NetworkChannel](pool: SelectorLoopPool)
                 extends ServerChannelFactory[Channel] {
-
-  def this(fixedPoolSize: Int, bufferSize: Int = 8*1024) = this(new FixedSelectorPool(fixedPoolSize, bufferSize))
 
   protected def doBind(address: SocketAddress): Channel
 

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerChannelFactory.scala
@@ -1,26 +1,36 @@
 package org.http4s.blaze
 package channel.nio1
 
+import org.http4s.blaze.util.BufferTools
 import org.http4s.blaze.channel.BufferPipelineBuilder
+import org.http4s.blaze.pipeline.Command.EOF
+
 import java.nio.channels._
 import java.net.SocketAddress
 import java.io.IOException
 import java.nio.ByteBuffer
-import org.http4s.blaze.util.BufferTools
 
 import scala.util.{Failure, Success, Try}
-import org.http4s.blaze.pipeline.Command.EOF
+
 import NIO1HeadStage._
 
-class NIO1SocketServerChannelFactory(pipeFactory: BufferPipelineBuilder,
-                                     pool: SelectorLoopPool)
+object NIO1SocketServerChannelFactory {
+  def apply(pipeFactory: BufferPipelineBuilder, pool: SelectorLoopPool): NIO1SocketServerChannelFactory =
+    new NIO1SocketServerChannelFactory(pipeFactory, pool)
+
+  def apply(pipeFactory: BufferPipelineBuilder,
+            workerThreads: Int = 8, bufferSize: Int = 4*1024): NIO1SocketServerChannelFactory = {
+    val pool = new FixedSelectorPool(workerThreads, bufferSize)
+    new NIO1SocketServerChannelFactory(pipeFactory, pool)
+  }
+}
+
+class NIO1SocketServerChannelFactory private(pipeFactory: BufferPipelineBuilder,
+                                             pool: SelectorLoopPool)
           extends NIO1ServerChannelFactory[ServerSocketChannel](pool)
 {
 
   import org.http4s.blaze.channel.ChannelHead.brokePipeMessages
-
-  def this(pipeFactory: BufferPipelineBuilder, workerThreads: Int = 8, bufferSize: Int = 4*1024) =
-    this(pipeFactory, new FixedSelectorPool(workerThreads, bufferSize))
 
   //////////////// End of constructors /////////////////////////////////////////////////////////
 

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerChannelFactory.scala
@@ -15,14 +15,23 @@ import scala.util.{Failure, Success, Try}
 import NIO1HeadStage._
 
 object NIO1SocketServerChannelFactory {
+
+  /** Default number of threads used to make a new [[SelectorLoopPool]] if not specified */
+  val defaultPoolSize: Int = Runtime.getRuntime.availableProcessors()*2 + 1
+
+  /** Default size of buffer to use in a [[SelectorLoop]] */
+  val defaultBufferSize: Int = 16*1024
+
   def apply(pipeFactory: BufferPipelineBuilder, pool: SelectorLoopPool): NIO1SocketServerChannelFactory =
     new NIO1SocketServerChannelFactory(pipeFactory, pool)
 
   def apply(pipeFactory: BufferPipelineBuilder,
-            workerThreads: Int = 8, bufferSize: Int = 4*1024): NIO1SocketServerChannelFactory = {
+            workerThreads: Int = defaultPoolSize, bufferSize: Int = defaultBufferSize): NIO1SocketServerChannelFactory = {
     val pool = new FixedSelectorPool(workerThreads, bufferSize)
     new NIO1SocketServerChannelFactory(pipeFactory, pool)
   }
+
+
 }
 
 class NIO1SocketServerChannelFactory private(pipeFactory: BufferPipelineBuilder,

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/NIO2SocketServerChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/NIO2SocketServerChannelFactory.scala
@@ -9,7 +9,13 @@ import org.http4s.blaze.channel._
 import org.http4s.blaze.pipeline.Command.Connected
 
 
-class NIO2SocketServerChannelFactory(pipeFactory: BufferPipelineBuilder, group: AsynchronousChannelGroup = null)
+object NIO2SocketServerChannelFactory {
+  def apply(pipeFactory: BufferPipelineBuilder, group: Option[AsynchronousChannelGroup] = None): NIO2SocketServerChannelFactory =
+    new NIO2SocketServerChannelFactory(pipeFactory, group.orNull)
+}
+
+class NIO2SocketServerChannelFactory private(pipeFactory: BufferPipelineBuilder,
+                                                   group: AsynchronousChannelGroup = null)
         extends ServerChannelFactory[AsynchronousServerSocketChannel] {
 
   def bind(localAddress: SocketAddress = null): ServerChannel = {

--- a/core/src/main/scala/org/http4s/blaze/channel/package.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/package.scala
@@ -5,6 +5,6 @@ import org.http4s.blaze.pipeline.LeafBuilder
 
 package object channel {
 
-    type BufferPipelineBuilder = SocketConnection => LeafBuilder[ByteBuffer]
+  type BufferPipelineBuilder = SocketConnection => LeafBuilder[ByteBuffer]
 
 }

--- a/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
@@ -2,11 +2,14 @@ package org.http4s.blaze.channel
 
 
 import java.net.InetSocketAddress
-import org.specs2.mutable.Specification
-import org.http4s.blaze.channel.nio2.NIO2SocketServerChannelFactory
-import org.log4s.getLogger
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
+
+import org.specs2.mutable.Specification
+
+import org.http4s.blaze.channel.nio2.NIO2SocketServerChannelFactory
+
+import org.log4s.getLogger
 
 
 class ChannelSpec extends Specification {
@@ -15,7 +18,7 @@ class ChannelSpec extends Specification {
     private[this] val logger = getLogger
 
     def prepare(address: InetSocketAddress): ServerChannel = {
-      val factory = new NIO2SocketServerChannelFactory(f)
+      val factory = NIO2SocketServerChannelFactory(f)
       factory.bind(address)
     }
 

--- a/examples/src/main/scala/org/http4s/blaze/examples/ClientAuthSSLHttpServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/ClientAuthSSLHttpServer.scala
@@ -25,7 +25,7 @@ class ClientAuthSSLHttpServer(port: Int) {
 
   val group = AsynchronousChannelGroup.withFixedThreadPool(Consts.poolSize, Executors.defaultThreadFactory())
 
-  private val factory = new NIO2SocketServerChannelFactory(f)
+  private val factory = NIO2SocketServerChannelFactory(f)
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/EchoServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/EchoServer.scala
@@ -23,8 +23,7 @@ class EchoServer {
   def prepare(address: InetSocketAddress): ServerChannel = {
     val f: BufferPipelineBuilder = _ => new EchoStage
 
-    val factory = new NIO2SocketServerChannelFactory(f)
-    factory.bind(address)
+    NIO2SocketServerChannelFactory(f).bind(address)
   }
   
   def run(port: Int) {

--- a/examples/src/main/scala/org/http4s/blaze/examples/NIO1HttpServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/NIO1HttpServer.scala
@@ -15,7 +15,7 @@ class NIO1HttpServer(port: Int) {
   private val f: BufferPipelineBuilder =
     status.wrapBuilder { _ => LeafBuilder(ExampleService.http1Stage(Some(status), 10*1024)) }
 
-  private val factory = new NIO1SocketServerChannelFactory(f, workerThreads = Consts.poolSize)
+  private val factory = NIO1SocketServerChannelFactory(f, workerThreads = Consts.poolSize)
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/NIO2HttpServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/NIO2HttpServer.scala
@@ -17,7 +17,7 @@ class NIO2HttpServer(port: Int) {
 
   private val status = new IntervalConnectionMonitor(10.minutes)
   private val f: BufferPipelineBuilder = _ => LeafBuilder(ExampleService.http1Stage(Some(status), 10*1024))
-  private val factory = new NIO2SocketServerChannelFactory(status.wrapBuilder(f))
+  private val factory = NIO2SocketServerChannelFactory(status.wrapBuilder(f))
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/SSLHttpServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/SSLHttpServer.scala
@@ -20,7 +20,7 @@ class SSLHttpServer(port: Int) {
     TrunkBuilder(new SSLStage(eng, 100*1024)).cap(ExampleService.http1Stage(None, 10*1024))
   }
 
-  private val factory = new NIO1SocketServerChannelFactory(f, workerThreads = Consts.poolSize)
+  private val factory = NIO1SocketServerChannelFactory(f, workerThreads = Consts.poolSize)
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/WebSocketServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/WebSocketServer.scala
@@ -22,7 +22,7 @@ class WebSocketServer(port: Int) {
 
   val group = AsynchronousChannelGroup.withFixedThreadPool(Consts.poolSize, Executors.defaultThreadFactory())
 
-  private val factory = new NIO2SocketServerChannelFactory(f)
+  private val factory = NIO2SocketServerChannelFactory(f)
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/http20/Http2Server.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/http20/Http2Server.scala
@@ -19,7 +19,7 @@ class Http2Server(port: Int) {
     TrunkBuilder(new SSLStage(eng)).cap(ProtocolSelector(eng, ExampleService.service(None), 1024*1024, 16*1024, ec))
   }
 
-  private val factory = new NIO1SocketServerChannelFactory(f, workerThreads = Consts.poolSize)
+  private val factory = NIO1SocketServerChannelFactory(f, workerThreads = Consts.poolSize)
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/spdy/SpdyServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/spdy/SpdyServer.scala
@@ -26,7 +26,7 @@ class SpdyServer(port: Int) {
 
   val group = AsynchronousChannelGroup.withFixedThreadPool(Consts.poolSize, Executors.defaultThreadFactory())
 
-  private val factory = new NIO2SocketServerChannelFactory(f)
+  private val factory = NIO2SocketServerChannelFactory(f)
 
   def run(): Unit = factory.bind(new InetSocketAddress(port)).run()
 }


### PR DESCRIPTION
Use companion object methods instead of `new` operators.

This is really a simple cleanup to make things more idiomatic scala and less java written in scala.