### PR TITLE
Clean up shutdown mechanisms.

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/ServerChannel.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ServerChannel.scala
@@ -17,7 +17,7 @@ abstract class ServerChannel extends Runnable with Closeable { self =>
 
   type C <: NetworkChannel
 
-  protected def channel: C
+  protected val channel: C
 
   /** Starts the accept loop, handing connections off to a thread pool */
   def run(): Unit

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1ServerChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1ServerChannelFactory.scala
@@ -29,17 +29,14 @@ abstract class NIO1ServerChannelFactory[Channel <: NetworkChannel](pool: Selecto
 
     type C = Channel
 
-    @volatile private var closed = false
-
     override def close(): Unit = {
-      closed = true
       pool.shutdown()
-      channel.close()
+      super.close()
     }
 
     // The accept thread just accepts connections and pawns them off on the SelectorLoop pool
     final def run(): Unit = {
-      while (channel.isOpen && !closed) {
+      while (channel.isOpen) {
         try {
           val p = pool.nextLoop()
           completeConnection(channel, p)

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -144,6 +144,7 @@ final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extend
   def close(): Unit = {
     logger.info(s"Shutting down SelectorLoop ${getName()}")
     _isClosed = true
+    selector.wakeup()
   }
 
   private def killSelector() {

--- a/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
 
+import org.http4s.blaze.channel.nio1.NIO1SocketServerChannelFactory
 import org.specs2.mutable.Specification
 
 import org.http4s.blaze.channel.nio2.NIO2SocketServerChannelFactory
@@ -14,11 +15,12 @@ import org.log4s.getLogger
 
 class ChannelSpec extends Specification {
 
-  class BasicServer(f: BufferPipelineBuilder) {
+  class BasicServer(f: BufferPipelineBuilder, nio2: Boolean) {
     private[this] val logger = getLogger
 
     def prepare(address: InetSocketAddress): ServerChannel = {
-      val factory = NIO2SocketServerChannelFactory(f)
+      val factory = if (nio2) NIO2SocketServerChannelFactory(f)
+                    else      NIO1SocketServerChannelFactory(f)
       factory.bind(address)
     }
 
@@ -31,39 +33,84 @@ class ChannelSpec extends Specification {
     }
   }
 
+  val CommonDelay = 1000
 
-  "Channels" should {
+  "NIO1 Channels" should {
+
+    val IsNIO2 = false
 
     "Bind the port and then be closed" in {
-      val channel = new BasicServer(_ => new EchoStage).prepare(new InetSocketAddress(0))
+      val channel = new BasicServer(_ => new EchoStage, IsNIO2).prepare(new InetSocketAddress(0))
+      val t = channel.runAsync
+      Thread.sleep(CommonDelay)
       channel.close()
+      t.join()
       true should_== true
     }
 
     "Execute shutdown hooks" in {
       val i = new AtomicInteger(0)
-      val channel = new BasicServer(_ => new EchoStage).prepare(new InetSocketAddress(0))
+      val channel = new BasicServer(_ => new EchoStage, IsNIO2).prepare(new InetSocketAddress(0))
       channel.addShutdownHook{ () => i.incrementAndGet() }
       val t = channel.runAsync()
       channel.close()
-      t.join(100)
+      t.join(CommonDelay)
 
       i.get should_== 1
     }
 
     "Execute shutdown hooks when one throws an exception" in {
       val i = new AtomicInteger(0)
-      val channel = new BasicServer(_ => new EchoStage).prepare(new InetSocketAddress(0))
+      val channel = new BasicServer(_ => new EchoStage, IsNIO2).prepare(new InetSocketAddress(0))
       channel.addShutdownHook{ () => i.incrementAndGet() }
       channel.addShutdownHook{ () => sys.error("Foo") }
       channel.addShutdownHook{ () => i.incrementAndGet() }
       val t = channel.runAsync()
       try channel.close()
       catch { case t: RuntimeException => i.incrementAndGet() }
-      t.join(100)
+      t.join(CommonDelay)
 
       i.get should_== 3
     }
   }
 
+
+  "NIO2 Channels" should {
+
+    val IsNIO2 = true
+
+    "Bind the port and then be closed" in {
+      val channel = new BasicServer(_ => new EchoStage, IsNIO2).prepare(new InetSocketAddress(0))
+      val t = channel.runAsync
+      Thread.sleep(CommonDelay)
+      channel.close()
+      t.join()
+      true should_== true
+    }
+
+    "Execute shutdown hooks" in {
+      val i = new AtomicInteger(0)
+      val channel = new BasicServer(_ => new EchoStage, IsNIO2).prepare(new InetSocketAddress(0))
+      channel.addShutdownHook{ () => i.incrementAndGet() }
+      val t = channel.runAsync()
+      channel.close()
+      t.join(CommonDelay)
+
+      i.get should_== 1
+    }
+
+    "Execute shutdown hooks when one throws an exception" in {
+      val i = new AtomicInteger(0)
+      val channel = new BasicServer(_ => new EchoStage, IsNIO2).prepare(new InetSocketAddress(0))
+      channel.addShutdownHook{ () => i.incrementAndGet() }
+      channel.addShutdownHook{ () => sys.error("Foo") }
+      channel.addShutdownHook{ () => i.incrementAndGet() }
+      val t = channel.runAsync()
+      try channel.close()
+      catch { case t: RuntimeException => i.incrementAndGet() }
+      t.join(CommonDelay)
+
+      i.get should_== 3
+    }
+  }
 }


### PR DESCRIPTION
This fixes https://github.com/http4s/http4s/issues/231.

NIO1 was neglecting shutdown hooks, among other things.
NIO2 was needlessly throwing errors.