### PR TITLE
Accept a bare LF in the status line and headers

### DIFF
--- a/http/src/main/java/org/http4s/blaze/http/http_parser/ParserBase.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/ParserBase.java
@@ -157,15 +157,12 @@ public abstract class ParserBase {
             else if (b == HttpTokens.TAB || allow8859 && b < 0) {
                 return (char)(b & 0xff);
             }
+            else if (b == HttpTokens.LF) {
+                    return (char)b; // A backend should accept a bare linefeed. http://tools.ietf.org/html/rfc2616#section-19.3
+            }
             else {
-                if (b == HttpTokens.LF) {
-                    shutdownParser();
-                    throw new BadRequest("LineFeed found without CR");
-                }
-                else {
-                    shutdownParser();
-                    throw new BadRequest("Invalid char: '" + (char)(b & 0xff) + "', 0x" + Integer.toHexString(b));
-                }
+                shutdownParser();
+                throw new BadRequest("Invalid char: '" + (char)(b & 0xff) + "', 0x" + Integer.toHexString(b));
             }
         }
 

--- a/http/src/test/scala/org/http4s/blaze/http/http_parser/ServerParserSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http_parser/ServerParserSpec.scala
@@ -110,20 +110,15 @@ class ServerParserSpec extends Specification {
     }
 
     "Parse the request line for HTTP" in {
-      val p = new Parser()
-      p.parseLine("POST /enlighten/calais.asmx HTTP/1.1\r\n") should_== (true)
+      new Parser().parseLine("POST /enlighten/calais.asmx HTTP/1.1\r\n") should_== (true)
 
-      //      p.s should_== ("Request('POST', '/enlighten/calais.asmx', 'http', 1.1)")
-      //      p.getState() should_== (ParserState.Idle)
+      new Parser().parseLine("POST /enlighten/calais.asmx HTTP/1.1\n") should_== (true)
     }
 
     "Parse the request line for HTTP in segments" in {
       val p = new Parser()
       p.parseLine("POST /enlighten/cala") should_== (false)
       p.parseLine("is.asmx HTTP/1.1\r\n") should_== (true)
-
-      //      p.s should_== ("Request('POST', '/enlighten/calais.asmx', 'http', 1.1)")
-      //      p.getState() should_== (ParserState.Idle)
     }
 
 


### PR DESCRIPTION
Associated with https://github.com/http4s/http4s/issues/236

This should be a no brainer: the old spec (http://tools.ietf.org/html/rfc2616#section-19.3) recommends allowing LF without the preceeding CR. Note I didn't see this in rfc 7230 which replaces 2616, but I believe it should still apply.

I'll merge this shortly unless there is objection.