### PR TITLE
Fix QuietTimeoutStage so that it will cancel unused resets after its shutdown

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/util/Cancellable.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/Cancellable.scala
@@ -1,0 +1,14 @@
+package org.http4s.blaze.util
+
+/**
+ * Created on 7/16/15.
+ */
+object Cancellable {
+  private[util] val noopCancel = new Cancellable {
+    def cancel(): Unit = ()
+  }
+}
+
+trait Cancellable {
+  def cancel(): Unit
+}

--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -273,12 +273,5 @@ class TickWheelExecutor(wheelSize: Int = 512, tick: Duration = 200.milli) {
   }
 }
 
-sealed trait Cancellable {
-  def cancel(): Unit
-}
 
-object Cancellable {
-  private[util] val noopCancel = new Cancellable {
-    def cancel(): Unit = {}
-  }
-}
+

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -32,5 +32,15 @@ class QuietTimeoutStageSpec extends TimeoutHelpers {
       pipe.sendOutboundCommand(Command.Disconnect)
       r
     }
+
+    "not schedule timeouts after the pipeline has been shut down" in {
+      val pipe = makePipeline(delay = 10.seconds, timeout = 1.seconds)
+      val f = pipe.channelRead()
+      pipe.sendOutboundCommand(Command.Disconnect)
+
+      checkFuture(f, 5.second) should throwA[Command.EOF.type]
+      Thread.sleep(4000)
+      pipe.getDisconnects must_==(0)
+    }
   }
 }


### PR DESCRIPTION
There was a condition where the tail performs a read/write request, and before it is honored, the pipeline gets shutdown (maybe by a disconnect). That disconnect shuts down the pipeline and cancels any pending timeouts. However, the pending IO request _should_ eventually resolve, and that will reset the stage again, scheduling another timeout.

This PR addresses this by flagging the atomic reference with a 'tag' which it checks when resetting the timeout and acts appropriately.