### PR TITLE
Add a lenient parsing mode for headers

### DIFF
--- a/http/src/main/java/org/http4s/blaze/http/http_parser/BaseExceptions.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/BaseExceptions.java
@@ -22,6 +22,12 @@ public class BaseExceptions {
         }
     }
 
+    public static class BadCharacter extends BadRequest {
+        public BadCharacter(String msg) {
+            super(msg);
+        }
+    }
+
     public static class BadResponse extends ParserException {
         public BadResponse(String msg) {
             super(msg);

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ClientParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ClientParser.java
@@ -5,19 +5,24 @@ import org.http4s.blaze.http.http_parser.BaseExceptions.*;
 
 public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
-    public Http1ClientParser(int maxRequestLineSize, int maxHeaderLength, int initialBufferSize, int maxChunkSize) {
-        super(initialBufferSize, maxHeaderLength, maxChunkSize);
+    public Http1ClientParser(int maxRequestLineSize, int maxHeaderLength, int initialBufferSize, int maxChunkSize,
+                             boolean isLenient) {
+        super(initialBufferSize, maxHeaderLength, maxChunkSize, isLenient);
         this.maxRequestLineSize = maxRequestLineSize;
 
         _internalReset();
     }
 
-    public Http1ClientParser(int initialBufferSize) {
-        this(2048, 40*1024, initialBufferSize, Integer.MAX_VALUE);
+    public Http1ClientParser(int initialBufferSize, boolean isLenient) {
+        this(2048, 40*1024, initialBufferSize, Integer.MAX_VALUE, isLenient);
+    }
+
+    public Http1ClientParser(boolean isLenient) {
+        this(10*1024, isLenient);
     }
 
     public Http1ClientParser() {
-        this(10*1024);
+        this(false);
     }
 
     // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ServerParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ServerParser.java
@@ -72,7 +72,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
     // the sole Constructor
 
     public Http1ServerParser(int maxReqLen, int maxHeaderLength, int initialBufferSize, int maxChunkSize) {
-        super(initialBufferSize, maxHeaderLength, maxChunkSize);
+        super(initialBufferSize, maxHeaderLength, maxChunkSize, false);
 
         this.maxRequestLineSize = maxReqLen;
         _internalReset();


### PR DESCRIPTION
I've tried to keep the changes to the minimum. I use a new exception (subclassed from `BadRequest`) to signal a bad symbol, and a new state in `parseHeaders` to skip until the end of the current header entry. For this I had to split `next()` to do reading and validation separately.

I guess you might also want some tests to go with this, but I'm not sure where to put them.