### PR TITLE
Topic/lenient parsers

### DIFF
--- a/http/src/main/java/org/http4s/blaze/http/http_parser/BaseExceptions.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/BaseExceptions.java
@@ -22,6 +22,12 @@ public class BaseExceptions {
         }
     }
 
+    public static class BadCharacter extends BadRequest {
+        public BadCharacter(String msg) {
+            super(msg);
+        }
+    }
+
     public static class BadResponse extends ParserException {
         public BadResponse(String msg) {
             super(msg);

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/BodyAndHeaderParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/BodyAndHeaderParser.java
@@ -15,6 +15,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
         START,
         HEADER_IN_NAME,
         HEADER_IN_VALUE,
+        HEADER_SKIP,
         END
     }
 
@@ -62,8 +63,8 @@ public abstract class BodyAndHeaderParser extends ParserBase {
 
     /* Constructor --------------------------------------------------------- */
 
-    protected BodyAndHeaderParser(int initialBufferSize, int headerSizeLimit, int maxChunkSize) {
-        super(initialBufferSize);
+    protected BodyAndHeaderParser(int initialBufferSize, int headerSizeLimit, int maxChunkSize, boolean isLenient) {
+        super(initialBufferSize, isLenient);
         this.headerSizeLimit = headerSizeLimit;
         this.maxChunkSize = maxChunkSize;
 
@@ -153,9 +154,20 @@ public abstract class BodyAndHeaderParser extends ParserBase {
                     resetLimit(headerSizeLimit);
 
                 case HEADER_IN_NAME:
-                    for(ch = next(in, false); ch != ':' && ch != HttpTokens.LF; ch = next(in, false)) {
-                        if (ch == 0) return false;
-                        putChar(ch);
+                    try {
+                        for(ch = next(in, false); ch != ':' && ch != HttpTokens.LF; ch = next(in, false)) {
+                            if (ch == 0) return false;
+                            putChar(ch);
+                        }
+                    } catch (BaseExceptions.BadCharacter c) {
+                        if (isLenient()) {
+                            _hstate = HeaderState.HEADER_SKIP;
+                            continue headerLoop;
+                        }
+                        else {
+                            shutdownParser();
+                            throw c;
+                        }
                     }
 
                     // Must be done with headers
@@ -190,9 +202,21 @@ public abstract class BodyAndHeaderParser extends ParserBase {
                     _hstate = HeaderState.HEADER_IN_VALUE;
 
                 case HEADER_IN_VALUE:
-                    for(ch = next(in, true); ch != HttpTokens.LF; ch = next(in, true)) {
-                        if (ch == 0) return false;
-                        putChar(ch);
+
+                    try {
+                        for(ch = next(in, true); ch != HttpTokens.LF; ch = next(in, true)) {
+                            if (ch == 0) return false;
+                            putChar(ch);
+                        }
+                    } catch (BaseExceptions.BadCharacter c) {
+                        if (isLenient()) {
+                            _hstate = HeaderState.HEADER_SKIP;
+                            continue headerLoop;
+                        }
+                        else {
+                            shutdownParser();
+                            throw c;
+                        }
                     }
 
                     String value;
@@ -268,6 +292,15 @@ public abstract class BodyAndHeaderParser extends ParserBase {
                     }
 
                     break;
+
+                case HEADER_SKIP:
+                    // discard the header
+                    clearBuffer();
+                    byte b;
+                    for(b = nextByte(in); b != HttpTokens.LF && b != 0; b = nextByte(in));
+                    if (b == 0) return false;
+                    _hstate = HeaderState.HEADER_IN_NAME;
+                    continue headerLoop;
 
                 case END:
                     shutdownParser();

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ClientParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ClientParser.java
@@ -5,19 +5,24 @@ import org.http4s.blaze.http.http_parser.BaseExceptions.*;
 
 public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
-    public Http1ClientParser(int maxRequestLineSize, int maxHeaderLength, int initialBufferSize, int maxChunkSize) {
-        super(initialBufferSize, maxHeaderLength, maxChunkSize);
+    public Http1ClientParser(int maxRequestLineSize, int maxHeaderLength, int initialBufferSize, int maxChunkSize,
+                             boolean isLenient) {
+        super(initialBufferSize, maxHeaderLength, maxChunkSize, isLenient);
         this.maxRequestLineSize = maxRequestLineSize;
 
         _internalReset();
     }
 
-    public Http1ClientParser(int initialBufferSize) {
-        this(2048, 40*1024, initialBufferSize, Integer.MAX_VALUE);
+    public Http1ClientParser(int initialBufferSize, boolean isLenient) {
+        this(2048, 40*1024, initialBufferSize, Integer.MAX_VALUE, isLenient);
+    }
+
+    public Http1ClientParser(boolean isLenient) {
+        this(10*1024, isLenient);
     }
 
     public Http1ClientParser() {
-        this(10*1024);
+        this(false);
     }
 
     // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ClientParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ClientParser.java
@@ -93,7 +93,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
                     case VERSION:
                         for(ch = next(in, false); ch != HttpTokens.SPACE && ch != HttpTokens.TAB; ch = next(in, false)) {
-                            if (ch == 0) return false;
+                            if (ch == HttpTokens.EMPTY_BUFF) return false;
                             putChar(ch);
                         }
 
@@ -125,7 +125,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
                         // Eat whitespace
                         for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
 
-                        if (ch == 0) return false;
+                        if (ch == HttpTokens.EMPTY_BUFF) return false;
 
                         if (!HttpTokens.isDigit(ch)) {
                             shutdownParser();
@@ -136,11 +136,10 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
                     case STATUS_CODE:
                         for(ch = next(in, false); HttpTokens.isDigit(ch); ch = next(in, false)) {
-                            if (ch == 0) return false;
                             _statusCode = 10*_statusCode + (ch - HttpTokens.ZERO);
                         }
 
-                        if (ch == 0) return false;  // Need more data
+                        if (ch == HttpTokens.EMPTY_BUFF) return false;  // Need more data
 
                         if (_statusCode < 100 || _statusCode >= 600) {
                             shutdownParser();
@@ -164,7 +163,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
                         // Eat whitespace
                         for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
 
-                        if (ch == 0) return false;
+                        if (ch == HttpTokens.EMPTY_BUFF) return false;
 
                         if (ch == HttpTokens.LF) {
                         	endResponseLineParsing("");
@@ -176,7 +175,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
                     case REASON:
                         for(ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
-                            if (ch == 0) return false;
+                            if (ch == HttpTokens.EMPTY_BUFF) return false;
                             putChar(ch);
                         }
 

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ServerParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ServerParser.java
@@ -72,7 +72,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
     // the sole Constructor
 
     public Http1ServerParser(int maxReqLen, int maxHeaderLength, int initialBufferSize, int maxChunkSize) {
-        super(initialBufferSize, maxHeaderLength, maxChunkSize);
+        super(initialBufferSize, maxHeaderLength, maxChunkSize, false);
 
         this.maxRequestLineSize = maxReqLen;
         _internalReset();

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ServerParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/Http1ServerParser.java
@@ -113,7 +113,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
                         putChar(ch);
                     }
 
-                    if (ch == 0) return false;
+                    if (ch == HttpTokens.EMPTY_BUFF) return false;
 
                     _methodString = getString();
                     clearBuffer();
@@ -131,14 +131,14 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
                     // Eat whitespace
                     for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
 
-                    if (ch == 0) return false;
+                    if (ch == HttpTokens.EMPTY_BUFF) return false;
 
                     putChar(ch);
                     _lineState = LineState.URI;
 
                 case URI:
                     for(ch = next(in, false); ch != HttpTokens.SPACE && ch != HttpTokens.TAB; ch = next(in, false)) {
-                        if (ch == 0) return false;
+                        if (ch == HttpTokens.EMPTY_BUFF) return false;
                         putChar(ch);
                     }
 
@@ -151,7 +151,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
                     // Eat whitespace
                     for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
 
-                    if (ch == 0) return false;
+                    if (ch == HttpTokens.EMPTY_BUFF) return false;
 
                     if (ch != 'H') {
                         shutdownParser();
@@ -163,7 +163,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
 
                 case REQUEST_VERSION:
                     for(ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
-                        if (ch == 0) return false;
+                        if (ch == HttpTokens.EMPTY_BUFF) return false;
                         putChar(ch);
                     }
 

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/HttpTokens.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/HttpTokens.java
@@ -1,10 +1,13 @@
 package org.http4s.blaze.http.http_parser;
 
-import org.http4s.blaze.http.http_parser.BaseExceptions.BadRequest;
+import org.http4s.blaze.http.http_parser.BaseExceptions.BadCharacter;
 
 
 public final class HttpTokens
 {
+    // Needs more input
+    static final char EMPTY_BUFF = 0xFFFF;
+
     // Terminal symbols.
     static final char COLON      = ':';
     static final char TAB        = '\t';
@@ -23,7 +26,7 @@ public final class HttpTokens
     final static byte f    = 'f';
     final static byte z    = 'z';
 
-    public static int hexCharToInt(final char ch) throws BadRequest {
+    public static int hexCharToInt(final char ch) throws BadCharacter {
         if (ZERO <= ch && ch <= NINE) {
             return ch - ZERO;
         }
@@ -34,7 +37,7 @@ public final class HttpTokens
             return ch - A + 10;
         }
         else {
-            throw new BadRequest("Bad hex char: " + (char)ch);
+            throw new BadCharacter("Bad hex char: " + (char)ch);
         }
     }
 

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/HttpTokens.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/HttpTokens.java
@@ -8,6 +8,9 @@ public final class HttpTokens
     // Needs more input
     static final char EMPTY_BUFF = 0xFFFF;
 
+    // replacement for invalid octets
+    static final char REPLACEMENT= 0xFFFD;
+
     // Terminal symbols.
     static final char COLON      = ':';
     static final char TAB        = '\t';

--- a/http/src/main/java/org/http4s/blaze/http/http_parser/ParserBase.java
+++ b/http/src/main/java/org/http4s/blaze/http/http_parser/ParserBase.java
@@ -171,7 +171,7 @@ public abstract class ParserBase {
                 return (char)b; // A backend should accept a bare linefeed. http://tools.ietf.org/html/rfc2616#section-19.3
             }
             else if (isLenient()) {
-                return (char)(b & 0xff);
+                return HttpTokens.REPLACEMENT;
             }
             else {
                 shutdownParser();

--- a/http/src/test/scala/org/http4s/blaze/http/http_parser/ParserBaseSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http_parser/ParserBaseSpec.scala
@@ -1,0 +1,42 @@
+package org.http4s.blaze.http.http_parser
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.http_parser.BaseExceptions.BadCharacter
+import org.specs2.mutable.Specification
+
+
+class ParserBaseSpec extends Specification {
+
+  class Base(isLenient: Boolean = false, limit: Int = 1024) extends ParserBase(10*1024, isLenient) {
+    resetLimit(limit)
+  }
+
+  "ParserBase.next" should {
+    "Provide the next valid char" in {
+      val buffer = ByteBuffer.wrap("OK".getBytes)
+        new Base().next(buffer, false) must_== 'O'.toByte
+    }
+
+    "Provide the EMPTY_BUFF token on empty ByteBuffer" in {
+      val buffer = ByteBuffer.allocate(0)
+      new Base().next(buffer, false) must_== HttpTokens.EMPTY_BUFF
+    }
+
+    "throw a BadCharacter if not lenient" in {
+      val buffer = ByteBuffer.allocate(1)
+      buffer.put(0x00.toByte)
+      buffer.flip()
+
+      new Base(isLenient = false).next(buffer, false) must throwA[BadCharacter]
+    }
+
+    "Provide a REPLACEMENT char on invalid character" in {
+      val buffer = ByteBuffer.allocate(1)
+      buffer.put(0x00.toByte)
+      buffer.flip()
+
+      new Base(isLenient = true).next(buffer, false) must_== HttpTokens.REPLACEMENT
+    }
+  }
+}


### PR DESCRIPTION
This adds the ability to parse the http1 request prelude in a more 'lenient' fashion.

One notable difference here is that leniency is applied to all characters, not just those in header fields. I don't think this is a good thing. I'm also not exactly convinced that its a good idea at all to accept illegal characters so this one may not make the cut.

See also #32
cc @clayrat