### PR TITLE
Topic/http2cleanup

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http20/AbstractStream.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/AbstractStream.scala
@@ -17,13 +17,13 @@ import scala.concurrent.{Future, Promise}
   * All operations should only be handled in a thread safe manner
   */
 private[http20] abstract class AbstractStream(val streamId: Int,
-                                             iStreamWindow: FlowWindow,
-                                             oStreamWindow: FlowWindow,
-                                         iConnectionWindow: FlowWindow,
-                                         oConnectionWindow: FlowWindow,
-                                                  settings: Settings,
-                                                     codec: Http20FrameDecoder with Http20FrameEncoder,
-                                             headerEncoder: HeaderEncoder) {
+                                              iStreamWindow: FlowWindow,
+                                              oStreamWindow: FlowWindow,
+                                              iConnectionWindow: FlowWindow,
+                                              oConnectionWindow: FlowWindow,
+                                              settings: Http2Settings,
+                                              codec: Http20FrameDecoder with Http20FrameEncoder,
+                                              headerEncoder: HeaderEncoder) {
 
   private sealed trait NodeState
   private case object Open extends NodeState
@@ -204,7 +204,7 @@ private[http20] abstract class AbstractStream(val streamId: Int,
   // Mutates the state of the flow control windows
   private def encodeMessages(msgs: Seq[Http2Msg], acc: mutable.Buffer[ByteBuffer]): Seq[Http2Msg] = {
     val maxWindow = math.min(oConnectionWindow(), oStreamWindow())
-    val (bytes, rem) = msgEncoder.encodeMessages(settings.max_frame_size, maxWindow, msgs, acc)
+    val (bytes, rem) = msgEncoder.encodeMessages(settings.maxFrameSize, maxWindow, msgs, acc)
     // track the bytes written and write the buffers
     oStreamWindow.window -= bytes
     oConnectionWindow.window -= bytes

--- a/http/src/main/scala/org/http4s/blaze/http/http20/FlowControl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/FlowControl.scala
@@ -14,7 +14,6 @@ import scala.collection.mutable
 import scala.concurrent.Future
 
 private class FlowControl(http2Stage: Http2StageConcurrentOps,
-                       inboundWindow: Int,
                            idManager: StreamIdManager,
                        http2Settings: Settings,
                                codec: Http20FrameDecoder with Http20FrameEncoder,
@@ -107,7 +106,7 @@ private class FlowControl(http2Stage: Http2StageConcurrentOps,
 
   final class Stream(streamId: Int)
     extends AbstractStream(streamId,
-      new FlowWindow(inboundWindow),
+      new FlowWindow(http2Settings.inboundWindow),
       new FlowWindow(http2Settings.outbound_initial_window_size),
       iConnectionWindow,
       oConnectionWindow,

--- a/http/src/main/scala/org/http4s/blaze/http/http20/FlowControl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/FlowControl.scala
@@ -14,16 +14,16 @@ import scala.collection.mutable
 import scala.concurrent.Future
 
 private class FlowControl(http2Stage: Http2StageConcurrentOps,
-                           idManager: StreamIdManager,
-                       http2Settings: Settings,
-                               codec: Http20FrameDecoder with Http20FrameEncoder,
-                       headerEncoder: HeaderEncoder) { self =>
+                          idManager: StreamIdManager,
+                          http2Settings: Http2Settings,
+                          codec: Http20FrameDecoder with Http20FrameEncoder,
+                          headerEncoder: HeaderEncoder) { self =>
 
 
   private val logger = getLogger
   private val nodeMap = new HashMap[Int, Stream]()
 
-  private val oConnectionWindow = new FlowWindow(http2Settings.outbound_initial_window_size)
+  private val oConnectionWindow = new FlowWindow(http2Settings.outboundInitialWindowSize)
   private val iConnectionWindow = new FlowWindow(http2Settings.inboundWindow)
 
   /////////////////////////// Stream management //////////////////////////////////////
@@ -94,9 +94,9 @@ private class FlowControl(http2Stage: Http2StageConcurrentOps,
   }
 
   def onInitialWindowSizeChange(newWindow: Int): Unit = {
-    val diff = newWindow - http2Settings.outbound_initial_window_size
+    val diff = newWindow - http2Settings.outboundInitialWindowSize
     logger.trace(s"Adjusting outbound windows by $diff")
-    http2Settings.outbound_initial_window_size = newWindow
+    http2Settings.outboundInitialWindowSize = newWindow
     oConnectionWindow.window += diff
 
     nodes().foreach { node =>
@@ -107,7 +107,7 @@ private class FlowControl(http2Stage: Http2StageConcurrentOps,
   final class Stream(streamId: Int)
     extends AbstractStream(streamId,
       new FlowWindow(http2Settings.inboundWindow),
-      new FlowWindow(http2Settings.outbound_initial_window_size),
+      new FlowWindow(http2Settings.outboundInitialWindowSize),
       iConnectionWindow,
       oConnectionWindow,
       http2Settings,

--- a/http/src/main/scala/org/http4s/blaze/http/http20/FrameHandler.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/FrameHandler.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.http20
 
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.http20.Settings.Setting
+import org.http4s.blaze.http.http20.Http2Settings.Setting
 
 trait FrameHandler {
 

--- a/http/src/main/scala/org/http4s/blaze/http/http20/HeaderDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/HeaderDecoder.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.US_ASCII
 
 import org.http4s.blaze.http.http20.Http2Exception._
-import org.http4s.blaze.http.http20.Settings.DefaultSettings
+import org.http4s.blaze.http.http20.Http2Settings.DefaultSettings
 import org.http4s.blaze.util.BufferTools
 
 import com.twitter.hpack.{Decoder, HeaderListener}

--- a/http/src/main/scala/org/http4s/blaze/http/http20/HeaderEncoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/HeaderEncoder.scala
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.US_ASCII
 
 import com.twitter.hpack.Encoder
-import org.http4s.blaze.http.http20.Settings.DefaultSettings
+import org.http4s.blaze.http.http20.Http2Settings.DefaultSettings
 
 
 /** Simple Headers type for use in blaze and testing */

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Http20FrameDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Http20FrameDecoder.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.http20
 
 import java.nio.ByteBuffer
 
-import Settings.Setting
+import Http2Settings.Setting
 import Http2Exception._
 
 import scala.collection.mutable.ArrayBuffer
@@ -14,7 +14,7 @@ trait Http20FrameDecoder {
   import bits._
 
   protected val handler: FrameHandler
-  protected val http2Settings: Settings
+  protected val http2Settings: Http2Settings
 
   /** Decode a data frame. */
   def decodeBuffer(buffer: ByteBuffer): Http2Result = {
@@ -33,7 +33,7 @@ trait Http20FrameDecoder {
     val streamId = buffer.getInt() & Masks.STREAMID
     // this concludes the 9 byte header. `in` is now to the payload
 
-    if (len > http2Settings.max_frame_size) {
+    if (len > http2Settings.maxFrameSize) {
       protoError(s"HTTP2 packet is to large to handle.", streamId)
     } else if (handler.inHeaderSequence() && frameType != FrameTypes.CONTINUATION) {
     // We are in the middle of some header frames which is a no-go

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Http20FrameEncoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Http20FrameEncoder.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.http20
 
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.http20.Settings.Setting
+import org.http4s.blaze.http.http20.Http2Settings.Setting
 import org.http4s.blaze.util.BufferTools
 
 trait Http20FrameEncoder {

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Http2Selector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Http2Selector.scala
@@ -43,12 +43,11 @@ object Http2Selector {
       LeafBuilder(new BasicHttpStage(streamId, maxBody, Duration.Inf, trampoline, service))
     }
 
-    new Http2Stage(
-      maxHeadersLength,
+    Http2Stage(
       node_builder = newNode,
       timeout = Duration.Inf,
-      maxInboundStreams = 300,
-      ec = ec
+      ec = ec,
+      maxHeadersLength = maxHeadersLength
     )
   }
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Http2Selector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Http2Selector.scala
@@ -44,7 +44,7 @@ object Http2Selector {
     }
 
     Http2Stage(
-      node_builder = newNode,
+      nodeBuilder = newNode,
       timeout = Duration.Inf,
       ec = ec,
       maxHeadersLength = maxHeadersLength

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Http2Settings.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Http2Settings.scala
@@ -1,10 +1,10 @@
 package org.http4s.blaze.http.http20
 
-import org.http4s.blaze.http.http20.Settings.DefaultSettings
+import org.http4s.blaze.http.http20.Http2Settings.DefaultSettings
 
 import scala.collection.mutable
 
-object Settings {
+object Http2Settings {
 
   type SettingValue = Long
 
@@ -46,14 +46,14 @@ object Settings {
   }
 }
 
-final class Settings(
-  var inboundWindow: Int = DefaultSettings.INITIAL_WINDOW_SIZE,
-  var outbound_initial_window_size: Int = DefaultSettings.INITIAL_WINDOW_SIZE,
-  var push_enable: Boolean = DefaultSettings.ENABLE_PUSH,                       // initially enabled
-  var max_inbound_streams: Int = DefaultSettings.MAX_CONCURRENT_STREAMS,        // initially unbounded
-  var max_outbound_streams: Int = DefaultSettings.MAX_CONCURRENT_STREAMS,       // initially unbounded
-  var max_frame_size: Int = DefaultSettings.MAX_FRAME_SIZE,
-  var max_header_size: Int = DefaultSettings.MAX_HEADER_LIST_SIZE               // initially unbounded
+final class Http2Settings(
+                           var inboundWindow: Int = DefaultSettings.INITIAL_WINDOW_SIZE,
+                           var outboundInitialWindowSize: Int = DefaultSettings.INITIAL_WINDOW_SIZE,
+                           var push_enable: Boolean = DefaultSettings.ENABLE_PUSH, // initially enabled
+                           var maxInboundStreams: Int = DefaultSettings.MAX_CONCURRENT_STREAMS, // initially unbounded
+                           var maxOutboundStreams: Int = DefaultSettings.MAX_CONCURRENT_STREAMS, // initially unbounded
+                           var maxFrameSize: Int = DefaultSettings.MAX_FRAME_SIZE,
+                           var maxHeaderSize: Int = DefaultSettings.MAX_HEADER_LIST_SIZE // initially unbounded
 ) {
   var receivedGoAway = false
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Settings.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Settings.scala
@@ -1,5 +1,7 @@
 package org.http4s.blaze.http.http20
 
+import org.http4s.blaze.http.http20.Settings.DefaultSettings
+
 import scala.collection.mutable
 
 object Settings {
@@ -35,23 +37,23 @@ object Settings {
   val MAX_HEADER_LIST_SIZE   = mkKey(0x6, "SETTINGS_MAX_HEADER_LIST_SIZE")
 
   object DefaultSettings {
-    def HEADER_TABLE_SIZE = 4096                                  //  Section 6.5.2
+    def HEADER_TABLE_SIZE = 4096                                  // Section 6.5.2
     def ENABLE_PUSH = true // 1                                   // Section 6.5.2
     def MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE // (infinite)  // Section 6.5.2
-    def INITIAL_WINDOW_SIZE = 65535                               // Section 6.5.2
-    def MAX_FRAME_SIZE = 16384                                    // Section 6.5.2
+    def INITIAL_WINDOW_SIZE = 65535                               // Section 6.5.2   2^16
+    def MAX_FRAME_SIZE = 16384                                    // Section 6.5.2   2^14
     def MAX_HEADER_LIST_SIZE = Integer.MAX_VALUE //(infinite)     // Section 6.5.2
   }
 }
 
-final class Settings(val inboundWindow: Int) {
-  import org.http4s.blaze.http.http20.Settings.DefaultSettings
-
+final class Settings(
+  var inboundWindow: Int = DefaultSettings.INITIAL_WINDOW_SIZE,
+  var outbound_initial_window_size: Int = DefaultSettings.INITIAL_WINDOW_SIZE,
+  var push_enable: Boolean = DefaultSettings.ENABLE_PUSH,                       // initially enabled
+  var max_inbound_streams: Int = DefaultSettings.MAX_CONCURRENT_STREAMS,        // initially unbounded
+  var max_outbound_streams: Int = DefaultSettings.MAX_CONCURRENT_STREAMS,       // initially unbounded
+  var max_frame_size: Int = DefaultSettings.MAX_FRAME_SIZE,
+  var max_header_size: Int = DefaultSettings.MAX_HEADER_LIST_SIZE               // initially unbounded
+) {
   var receivedGoAway = false
-
-  var outbound_initial_window_size = DefaultSettings.INITIAL_WINDOW_SIZE
-  var push_enable = DefaultSettings.ENABLE_PUSH                           // initially enabled
-  var max_outbound_streams = DefaultSettings.MAX_CONCURRENT_STREAMS       // initially unbounded.
-  var max_frame_size = DefaultSettings.MAX_FRAME_SIZE
-  var max_header_size = DefaultSettings.MAX_HEADER_LIST_SIZE              // initially unbounded
 }

--- a/http/src/test/scala/org/http4s/blaze/http/http20/Http20FrameCodecSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http20/Http20FrameCodecSpec.scala
@@ -44,10 +44,12 @@ class Http20FrameCodecSpec extends Specification {
     joinBuffers(buffers :+ ByteBuffer.allocate(bonusSize))
   }
 
-  def decoder(h: FrameHandler, inHeaders: Boolean = false) = new Http20FrameDecoder {
-    def handler = h
 
+  class TestHttp20FrameDecoder(val handler: FrameHandler) extends Http20FrameDecoder {
+    override val http2Settings = new Settings()
   }
+
+  def decoder(h: FrameHandler, inHeaders: Boolean = false) = new TestHttp20FrameDecoder(h)
 
   def encoder = new Http20FrameEncoder {}
 

--- a/http/src/test/scala/org/http4s/blaze/http/http20/Http20FrameCodecSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http20/Http20FrameCodecSpec.scala
@@ -3,7 +3,7 @@ package org.http4s.blaze.http.http20
 import java.nio.ByteBuffer
 
 import org.http4s.blaze.http.Headers
-import org.http4s.blaze.http.http20.Settings.Setting
+import org.http4s.blaze.http.http20.Http2Settings.Setting
 import org.http4s.blaze.util.BufferTools
 import org.http4s.blaze.util.BufferTools._
 
@@ -46,7 +46,7 @@ class Http20FrameCodecSpec extends Specification {
 
 
   class TestHttp20FrameDecoder(val handler: FrameHandler) extends Http20FrameDecoder {
-    override val http2Settings = new Settings()
+    override val http2Settings = new Http2Settings()
   }
 
   def decoder(h: FrameHandler, inHeaders: Boolean = false) = new TestHttp20FrameDecoder(h)

--- a/http/src/test/scala/org/http4s/blaze/http/http20/MockFrameHandler.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http20/MockFrameHandler.scala
@@ -3,7 +3,7 @@ package http20
 
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.http20.Settings.Setting
+import org.http4s.blaze.http.http20.Http2Settings.Setting
 
 class MockFrameHandler(inHeaders: Boolean) extends FrameHandler {
   override def inHeaderSequence(): Boolean = inHeaders


### PR DESCRIPTION
__Do not merge: we are currently on snapshots in the http4s repo and this will break it. A PR for http4s should happen at the same time.__

The first commit (9aab681) hardens the http2 codec and fixes a few bugs laying around in it. Now the MAX_FRAME_SIZE value is checked during decoding to avoid OOM inducing DOS attacks.

The second commit (81d5d0d) cleans up some naming that was clearly silly.