### PR TITLE
Work around the java Socket "memory leak"

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
@@ -231,6 +231,7 @@ class NIO1SocketServerGroup(pool: SelectorLoopPool) extends ServerChannelGroup {
           scratch.clear()
           BufferTools.copyBuffers(buffers, scratch)
           scratch.flip()
+
           val size = scratch.remaining()
           ch.write(scratch)
           val written = size - scratch.remaining()

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
@@ -5,24 +5,24 @@ package nio1
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels._
-import java.net.{InetSocketAddress, SocketAddress}
+import java.net.InetSocketAddress
 import java.util.Date
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicReference
 
 import org.http4s.blaze.channel.ChannelHead._
-import org.http4s.blaze.channel.nio1.NIO1HeadStage.{WriteError, Incomplete, Complete, WriteResult}
+import org.http4s.blaze.channel.nio1.NIO1HeadStage.{Complete, Incomplete, WriteError, WriteResult}
 import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.util.BufferTools
 import org.log4s._
 
+import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 object NIO1SocketServerGroup {
 
   /** Default size of buffer to use in a [[SelectorLoop]] */
-  val defaultBufferSize: Int = 32*1024
+  val defaultBufferSize: Int = 64*1024
 
   def apply(pool: SelectorLoopPool): NIO1SocketServerGroup =
     new NIO1SocketServerGroup(pool)
@@ -125,7 +125,7 @@ class NIO1SocketServerGroup(pool: SelectorLoopPool) extends ServerChannelGroup {
 
               // check to see if we want to keep this connection
               if (acceptConnection(address)) {
-                clientChannel.setOption[java.lang.Boolean](java.net.StandardSocketOptions.TCP_NODELAY, false)
+                clientChannel.setOption[java.lang.Boolean](java.net.StandardSocketOptions.TCP_NODELAY, true)
                 loop.initChannel(service, clientChannel, key => new SocketChannelHead(clientChannel, loop, key))
               }
               else clientChannel.close()
@@ -220,6 +220,8 @@ class NIO1SocketServerGroup(pool: SelectorLoopPool) extends ServerChannelGroup {
       try {
         if (BufferTools.areDirectOrEmpty(buffers)) {
           ch.write(buffers)
+          if (util.BufferTools.checkEmpty(buffers)) Complete
+          else Incomplete
         } else {
           // To sidestep the java NIO "memory leak" (see http://www.evanjones.ca/java-bytebuffer-leak.html)
           // We copy the data to the scratch buffer (which should be a direct ByteBuffer)
@@ -228,18 +230,31 @@ class NIO1SocketServerGroup(pool: SelectorLoopPool) extends ServerChannelGroup {
           // This is very similar to the pattern used by the Oracle JDK implementation in its
           // IOUtil class: if the provided buffers are not direct buffers, they are copied to
           // temporary direct ByteBuffers and written.
-          scratch.clear()
-          BufferTools.copyBuffers(buffers, scratch)
-          scratch.flip()
+          @tailrec
+          def writeLoop(): WriteResult = {
+            scratch.clear()
+            BufferTools.copyBuffers(buffers, scratch)
+            scratch.flip()
 
-          val size = scratch.remaining()
-          ch.write(scratch)
-          val written = size - scratch.remaining()
-          assert(BufferTools.fastForwardBuffers(buffers, written))
+            val written = ch.write(scratch)
+            if (written > 0) {
+              assert(BufferTools.fastForwardBuffers(buffers, written))
+            }
+
+            if (scratch.remaining() > 0) {
+              // Couldn't write all the data
+              Incomplete
+            } else if (util.BufferTools.checkEmpty(buffers)) {
+              // All data was written
+              Complete
+            } else {
+              // May still be able to write more to the socket buffer
+              writeLoop()
+            }
+          }
+
+          writeLoop()
         }
-
-        if (util.BufferTools.checkEmpty(buffers)) Complete
-        else Incomplete
       }
       catch {
         case e: ClosedChannelException => WriteError(EOF)

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -104,7 +104,8 @@ final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extend
 
   // Main thread method. The loop will break if the Selector loop is closed
   override def run() {
-    val scratch = BufferTools.allocate(bufferSize) // could be allocateDirect ?
+    // The scratch buffer is a direct buffer as this will often be used for I/O
+    val scratch = BufferTools.allocateDirect(bufferSize)
 
     try while(!_isClosed) {
       // Run any pending tasks. These may set interest ops, just compute something, etc.

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -18,7 +18,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
 
   def name: String = "ByteBufferHeadStage"
 
-  private val buffer = BufferTools.allocate(bufferSize)
+  private val buffer = BufferTools.allocateDirect(bufferSize)
 
   override def writeRequest(data: ByteBuffer): Future[Unit] = {
 
@@ -95,7 +95,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
       def completed(i: Integer, attachment: Null) {
         if (i.intValue() >= 0) {
           buffer.flip()
-          val b = BufferTools.allocate(buffer.remaining())
+          val b = BufferTools.allocateHeap(buffer.remaining())
           b.put(buffer).flip()
           p.trySuccess(b)
         } else {   // must be end of stream

--- a/core/src/main/scala/org/http4s/blaze/util/BufferTools.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/BufferTools.scala
@@ -9,20 +9,34 @@ import scala.concurrent.Future
 object BufferTools {
 
   /** Cached empty `ByteBuffer` */
-  val emptyBuffer: ByteBuffer = allocate(0)
+  val emptyBuffer: ByteBuffer = allocateHeap(0)
 
   /** Cached `Future` containing and empty `ByteBuffer` */
   val emptyFutureBuffer: Future[ByteBuffer] = Future.successful(emptyBuffer)
 
-  /** Allocate a fresh `ByteBuffer`
+  /** Allocate a new `ByteBuffer` on the heap
+    *
+    * This is an alias for [[allocateHeap]]
     *
     * @param size size of desired `ByteBuffer`
     */
-  def allocate(size: Int): ByteBuffer = ByteBuffer.allocate(size)
+  def allocate(size: Int): ByteBuffer = allocateHeap(size)
 
-  /** Make a copy of the ByteBuffer, zeroing the input buffer */
+  /** Allocate a new `ByteBuffer` on the heap
+    *
+    * @param size size of desired `ByteBuffer`
+    */
+  def allocateHeap(size: Int): ByteBuffer = ByteBuffer.allocate(size)
+
+  /** Allocate a new direct `ByteBuffer`
+    *
+    * @param size size of desired `ByteBuffer`
+    */
+  def allocateDirect(size: Int): ByteBuffer = ByteBuffer.allocateDirect(size)
+
+  /** Make a copy of the ByteBuffer, depleting the input buffer */
   def copyBuffer(b: ByteBuffer): ByteBuffer = {
-    val bb = allocate(b.remaining())
+    val bb = allocateHeap(b.remaining())
     bb.put(b).flip()
     bb
   }
@@ -33,7 +47,7 @@ object BufferTools {
     case Seq(b) => b
     case _      =>
       val sz = buffers.foldLeft(0)((sz, o) => sz + o.remaining())
-      val b = allocate(sz)
+      val b = allocateHeap(sz)
       buffers.foreach(b.put)
 
       b.flip()
@@ -75,7 +89,7 @@ object BufferTools {
         oldbuff
       }
       else {  // Need to make a larger buffer
-        val n = allocate(oldbuff.remaining() + newbuff.remaining())
+        val n = allocateHeap(oldbuff.remaining() + newbuff.remaining())
         n.put(oldbuff)
          .put(newbuff)
          .flip()
@@ -126,5 +140,83 @@ object BufferTools {
   def mkString(buffers: Seq[ByteBuffer],charset: Charset = StandardCharsets.UTF_8): String = {
     val b = joinBuffers(buffers)
     charset.decode(b).toString()
+  }
+
+  /** Copies as much data from the input buffers as possible without modifying positions
+    * of the input buffers
+    *
+    * @param buffers collection of buffers to copy. This may be an empty array and the array
+    *             may contain `null` elements. The positions, marks, and marks of the input
+    *             buffers will not be modified.
+    * @param out `ByteBuffer` that the data will be copied into. This must not be `null``
+    * @return Number of bytes copied.
+    */
+  private[blaze] def copyBuffers(buffers: Array[ByteBuffer], out: ByteBuffer): Int = {
+    val start = out.position()
+
+    @tailrec
+    def go(i: Int): Unit = {
+      if (!out.hasRemaining || i >= buffers.length) ()
+      else if (buffers(i) == null || !buffers(i).hasRemaining) go(i + 1)
+      else {
+        val buffer = buffers(i)
+        // Need to store the state and ensure we don't overflow the output buffer
+        val position = buffer.position()
+        val limit = buffer.limit()
+        buffer.limit(math.min(limit, out.remaining()))
+        out.put(buffer)
+
+        // Reset the buffers position and limit
+        buffer.limit(limit)
+        buffer.position(position)
+        go(i + 1)
+      }
+    }
+
+    go(0)
+
+    out.position() - start
+  }
+
+  /** Forward the positions of the collection of `ByteBuffer`s
+    *
+    * @param buffers `ByteBuffers` to modify. The positions will be incremented from the
+    *               first in the collection to the last.
+    * @param size Number of bytes to fast-forward the arrays
+    * @return whether there was enough bytes in the collection of buffers or if the size
+    *         overran the available data.
+    */
+  private[blaze] def fastForwardBuffers(buffers: Array[ByteBuffer], size: Int): Boolean = {
+    require(size >= 0)
+    @tailrec
+    def go(i: Int, remaining: Int): Int = {
+      if (remaining == 0 || i >= buffers.length) remaining
+      else {
+        val buffer = buffers(i)
+        if (buffer == null || !buffer.hasRemaining) go (i + 1, remaining)
+        else {
+          val toForward = math.min(remaining, buffer.remaining())
+          buffer.position(buffer.position() + toForward)
+          go(i + 1, remaining - toForward)
+        }
+      }
+    }
+
+    go(0, size) == 0
+  }
+
+  /** Check if all the `ByteBuffer`s in the array are either direct, empty, or null */
+  private[blaze] def areDirectOrEmpty(buffers: Array[ByteBuffer]): Boolean = {
+    @tailrec
+    def go(i: Int): Boolean = {
+      if (i >= buffers.length) true
+      else {
+        val buffer = buffers(i)
+        if (buffer == null || buffer.isDirect || !buffer.hasRemaining) go(i + 1)
+        else false
+      }
+    }
+
+    go(0)
   }
 }

--- a/core/src/main/scala/org/http4s/blaze/util/BufferTools.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/BufferTools.scala
@@ -163,7 +163,7 @@ object BufferTools {
         // Need to store the state and ensure we don't overflow the output buffer
         val position = buffer.position()
         val limit = buffer.limit()
-        buffer.limit(math.min(limit, out.remaining()))
+        buffer.limit(math.min(limit, position + out.remaining()))
         out.put(buffer)
 
         // Reset the buffers position and limit

--- a/core/src/main/scala/org/http4s/blaze/util/ScratchBuffer.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/ScratchBuffer.scala
@@ -3,7 +3,7 @@ package org.http4s.blaze.util
 import java.nio.ByteBuffer
 import org.log4s.getLogger
 
-
+// TODO: this is dangerous and should be removed
 abstract class ScratchBuffer {
   private[this] val logger = getLogger
   private val localBuffer = new ThreadLocal[ByteBuffer]
@@ -13,7 +13,7 @@ abstract class ScratchBuffer {
 
     if (b == null || b.capacity() < size) {
       logger.trace(s"Allocating thread local ByteBuffer($size)")
-      val b = BufferTools.allocate(size)
+      val b = BufferTools.allocateHeap(size)
       localBuffer.set(b)
       b
     } else {

--- a/core/src/test/scala/org/http4s/blaze/channel/EchoStage.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/EchoStage.scala
@@ -20,7 +20,7 @@ class EchoStage extends TailStage[ByteBuffer] {
   final override def stageStartup(): Unit = {
     channelRead().onComplete{
       case Success(buff) =>
-        val b = BufferTools.allocate(buff.remaining() + msg.length)
+        val b = BufferTools.allocateHeap(buff.remaining() + msg.length)
         b.put(msg).put(buff).flip()
 
         // Write it, wait for conformation, and start again

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/ByteToObjectStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/ByteToObjectStageSpec.scala
@@ -19,7 +19,7 @@ class ByteToObjectStageSpec extends Specification {
     def name: String = "TestCodec"
 
     def messageToBuffer(in: Msg): Seq[ByteBuffer] = {
-      val b = BufferTools.allocate(3)
+      val b = BufferTools.allocateHeap(3)
       b.put(in.tag)
       in match {
         case One(byte) => b.put(byte)
@@ -50,13 +50,13 @@ class ByteToObjectStageSpec extends Specification {
   }
 
   def oneBuffer = {
-    val b = BufferTools.allocate(2)
+    val b = BufferTools.allocateHeap(2)
     b.put(0.toByte).put(1.toByte).flip()
     b
   }
 
   def twoBuffer = {
-    val b = BufferTools.allocate(3)
+    val b = BufferTools.allocateHeap(3)
     b.put(1.toByte).putShort(2.toShort).flip()
     b
   }
@@ -112,7 +112,7 @@ class ByteToObjectStageSpec extends Specification {
     }
 
     "Decode one large buffer" in {
-      val b = BufferTools.allocate(oneBuffer.remaining() + twoBuffer.remaining())
+      val b = BufferTools.allocateHeap(oneBuffer.remaining() + twoBuffer.remaining())
       b.put(oneBuffer).put(twoBuffer)
       b.flip()
 
@@ -122,11 +122,11 @@ class ByteToObjectStageSpec extends Specification {
     }
 
     "Decode a series of one byte buffers" in {
-      val b = BufferTools.allocate(oneBuffer.remaining() + twoBuffer.remaining())
+      val b = BufferTools.allocateHeap(oneBuffer.remaining() + twoBuffer.remaining())
       b.put(oneBuffer).put(twoBuffer)
 
       val buffs = b.array().map{ byte =>
-        val b = BufferTools.allocate(1)
+        val b = BufferTools.allocateHeap(1)
         b.put(byte).flip()
         b
       }

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
@@ -235,7 +235,7 @@ class SSLStageSpec extends Specification {
           handShake()
 
         case NEED_WRAP =>
-          val o = BufferTools.allocate(maxNetSize)
+          val o = BufferTools.allocateHeap(maxNetSize)
           val r = engine.wrap(BufferTools.emptyBuffer, o)
           if (debug) println(r)
           o.flip()
@@ -260,7 +260,7 @@ class SSLStageSpec extends Specification {
       if (debug) println("ReadReq: " + engine.getHandshakeStatus)
       def go(buffer: ByteBuffer): Future[ByteBuffer] = {
         try {
-          val o = BufferTools.allocate(maxNetSize)
+          val o = BufferTools.allocateHeap(maxNetSize)
           val r = engine.wrap(buffer, o)
           o.flip()
 
@@ -309,7 +309,7 @@ class SSLStageSpec extends Specification {
 
       def go(data: ByteBuffer): Future[Unit] = {
         try {
-          val o = BufferTools.allocate(maxNetSize)
+          val o = BufferTools.allocateHeap(maxNetSize)
           val r = engine.unwrap(data, o)
           if (debug) println("Write Go: " + r)
           o.flip()


### PR DESCRIPTION
Problem

The java NIO implementation leaks direct memory because of the
way that it caches temporary direct ByteBuffers. This can lead
to OOM like errors.

Solution

Ensure that the scratch buffer is a direct ByteBuffer, and copy
heap buffers into it before writing, essentially stepping around
the logic that the JDK uses to write heap buffers.

Details

- Add additional allocation methods to BufferTools to be more
explicit.

- Use direct ByteBuffers for the scratch buffers in in NIO1 and NIO2
because they will most often be talking directly to the socket and
would necessitate a copy.

- Make tools for copying and fast forwarding ByteBuffers

- Fix the memory leak.

- Be awesome.