### PR TITLE
Work around the java Socket "memory leak"

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -1,16 +1,16 @@
 package org.http4s.blaze.channel.nio1
 
 
-import org.http4s.blaze.pipeline.{ Command => Cmd }
+import org.http4s.blaze.pipeline.{Command => Cmd}
 import org.http4s.blaze.util.BufferTools
 import org.http4s.blaze.pipeline._
 import org.http4s.blaze.channel.BufferPipelineBuilder
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
 import java.nio.channels._
 import java.io.IOException
+import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.RejectedExecutionException
 
@@ -104,7 +104,8 @@ final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extend
 
   // Main thread method. The loop will break if the Selector loop is closed
   override def run() {
-    val scratch = BufferTools.allocate(bufferSize) // could be allocateDirect ?
+    // The scratch buffer is a direct buffer as this will often be used for I/O
+    val scratch = ByteBuffer.allocateDirect(bufferSize)
 
     try while(!_isClosed) {
       // Run any pending tasks. These may set interest ops, just compute something, etc.

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -18,7 +18,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
 
   def name: String = "ByteBufferHeadStage"
 
-  private val buffer = BufferTools.allocate(bufferSize)
+  private val buffer = ByteBuffer.allocateDirect(bufferSize)
 
   override def writeRequest(data: ByteBuffer): Future[Unit] = {
 
@@ -95,7 +95,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
       def completed(i: Integer, attachment: Null) {
         if (i.intValue() >= 0) {
           buffer.flip()
-          val b = BufferTools.allocate(buffer.remaining())
+          val b = ByteBuffer.allocate(buffer.remaining())
           b.put(buffer).flip()
           p.trySuccess(b)
         } else {   // must be end of stream

--- a/core/src/main/scala/org/http4s/blaze/util/ScratchBuffer.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/ScratchBuffer.scala
@@ -3,7 +3,7 @@ package org.http4s.blaze.util
 import java.nio.ByteBuffer
 import org.log4s.getLogger
 
-
+// TODO: this is dangerous and should be removed
 abstract class ScratchBuffer {
   private[this] val logger = getLogger
   private val localBuffer = new ThreadLocal[ByteBuffer]
@@ -13,7 +13,7 @@ abstract class ScratchBuffer {
 
     if (b == null || b.capacity() < size) {
       logger.trace(s"Allocating thread local ByteBuffer($size)")
-      val b = BufferTools.allocate(size)
+      val b = ByteBuffer.allocate(size)
       localBuffer.set(b)
       b
     } else {

--- a/core/src/test/scala/org/http4s/blaze/channel/EchoStage.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/EchoStage.scala
@@ -3,7 +3,6 @@ package channel
 
 import org.http4s.blaze.pipeline.TailStage
 import java.nio.ByteBuffer
-import org.http4s.blaze.util.BufferTools
 
 import scala.util.{Failure, Success}
 import org.http4s.blaze.pipeline.Command.EOF
@@ -20,7 +19,7 @@ class EchoStage extends TailStage[ByteBuffer] {
   final override def stageStartup(): Unit = {
     channelRead().onComplete{
       case Success(buff) =>
-        val b = BufferTools.allocate(buff.remaining() + msg.length)
+        val b = ByteBuffer.allocate(buff.remaining() + msg.length)
         b.put(msg).put(buff).flip()
 
         // Write it, wait for conformation, and start again

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/ByteToObjectStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/ByteToObjectStageSpec.scala
@@ -19,7 +19,7 @@ class ByteToObjectStageSpec extends Specification {
     def name: String = "TestCodec"
 
     def messageToBuffer(in: Msg): Seq[ByteBuffer] = {
-      val b = BufferTools.allocate(3)
+      val b = ByteBuffer.allocate(3)
       b.put(in.tag)
       in match {
         case One(byte) => b.put(byte)
@@ -50,13 +50,13 @@ class ByteToObjectStageSpec extends Specification {
   }
 
   def oneBuffer = {
-    val b = BufferTools.allocate(2)
+    val b = ByteBuffer.allocate(2)
     b.put(0.toByte).put(1.toByte).flip()
     b
   }
 
   def twoBuffer = {
-    val b = BufferTools.allocate(3)
+    val b = ByteBuffer.allocate(3)
     b.put(1.toByte).putShort(2.toShort).flip()
     b
   }
@@ -112,7 +112,7 @@ class ByteToObjectStageSpec extends Specification {
     }
 
     "Decode one large buffer" in {
-      val b = BufferTools.allocate(oneBuffer.remaining() + twoBuffer.remaining())
+      val b = ByteBuffer.allocate(oneBuffer.remaining() + twoBuffer.remaining())
       b.put(oneBuffer).put(twoBuffer)
       b.flip()
 
@@ -122,11 +122,11 @@ class ByteToObjectStageSpec extends Specification {
     }
 
     "Decode a series of one byte buffers" in {
-      val b = BufferTools.allocate(oneBuffer.remaining() + twoBuffer.remaining())
+      val b = ByteBuffer.allocate(oneBuffer.remaining() + twoBuffer.remaining())
       b.put(oneBuffer).put(twoBuffer)
 
       val buffs = b.array().map{ byte =>
-        val b = BufferTools.allocate(1)
+        val b = ByteBuffer.allocate(1)
         b.put(byte).flip()
         b
       }

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
@@ -235,7 +235,7 @@ class SSLStageSpec extends Specification {
           handShake()
 
         case NEED_WRAP =>
-          val o = BufferTools.allocate(maxNetSize)
+          val o = ByteBuffer.allocateDirect(maxNetSize)
           val r = engine.wrap(BufferTools.emptyBuffer, o)
           if (debug) println(r)
           o.flip()
@@ -260,7 +260,7 @@ class SSLStageSpec extends Specification {
       if (debug) println("ReadReq: " + engine.getHandshakeStatus)
       def go(buffer: ByteBuffer): Future[ByteBuffer] = {
         try {
-          val o = BufferTools.allocate(maxNetSize)
+          val o = ByteBuffer.allocate(maxNetSize)
           val r = engine.wrap(buffer, o)
           o.flip()
 
@@ -309,7 +309,8 @@ class SSLStageSpec extends Specification {
 
       def go(data: ByteBuffer): Future[Unit] = {
         try {
-          val o = BufferTools.allocate(maxNetSize)
+          //
+          val o = ByteBuffer.allocate(maxNetSize)
           val r = engine.unwrap(data, o)
           if (debug) println("Write Go: " + r)
           o.flip()

--- a/core/src/test/scala/org/http4s/blaze/util/BufferToolsSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/util/BufferToolsSpec.scala
@@ -3,12 +3,10 @@ package org.http4s.blaze.util
 import org.specs2.mutable._
 import java.nio.ByteBuffer
 
-import BufferTools._
-
 class BufferToolsSpec extends Specification {
 
   def b(i: Int = 1) = {
-    val b = BufferTools.allocate(4)
+    val b = ByteBuffer.allocate(4)
     b.putInt(i).flip()
     b
   }
@@ -36,7 +34,7 @@ class BufferToolsSpec extends Specification {
     }
 
     "append the result of one to the end of another if there is room" in {
-      val b1 = BufferTools.allocate(9)
+      val b1 = ByteBuffer.allocate(9)
       b1.position(1) // offset by 1 to simulated already having read a byte
       b1.putInt(1).flip().position(1)
       val b2 = b(2)
@@ -49,7 +47,7 @@ class BufferToolsSpec extends Specification {
     }
 
     "compact a buffer to fit the second" in {
-      val b1 = BufferTools.allocate(8)
+      val b1 = ByteBuffer.allocate(8)
       b1.putInt(0).putInt(1).flip()
       b1.getInt() // Discard the first element
       val b2 = b(2)
@@ -64,55 +62,203 @@ class BufferToolsSpec extends Specification {
   "BufferTools.checkEmpty" should {
 
     "check if buffers are empty" in {
-      checkEmpty(Array(allocate(0), allocate(3))) must_== false
-      checkEmpty(Seq(allocate(0), allocate(3))) must_== false
+      BufferTools.checkEmpty(Array(ByteBuffer.allocate(0), ByteBuffer.allocate(3))) must_== false
+      BufferTools.checkEmpty(Seq(ByteBuffer.allocate(0), ByteBuffer.allocate(3))) must_== false
 
-      checkEmpty(Array(allocate(0), allocate(0))) must_== true
-      checkEmpty(Seq(allocate(0), allocate(0))) must_== true
+      BufferTools.checkEmpty(Array(ByteBuffer.allocate(0), ByteBuffer.allocate(0))) must_== true
+      BufferTools.checkEmpty(Seq(ByteBuffer.allocate(0), ByteBuffer.allocate(0))) must_== true
 
-      checkEmpty(Array(allocate(3))) must_== false
-      checkEmpty(Seq(allocate(3))) must_== false
+      BufferTools.checkEmpty(Array(ByteBuffer.allocate(3))) must_== false
+      BufferTools.checkEmpty(Seq(ByteBuffer.allocate(3))) must_== false
 
-      checkEmpty(Array(allocate(0))) must_== true
-      checkEmpty(Seq(allocate(0))) must_== true
+      BufferTools.checkEmpty(Array(ByteBuffer.allocate(0))) must_== true
+      BufferTools.checkEmpty(Seq(ByteBuffer.allocate(0))) must_== true
 
-      checkEmpty(Array[ByteBuffer]()) must_== true
-      checkEmpty(Seq()) must_== true
+      BufferTools.checkEmpty(Array[ByteBuffer]()) must_== true
+      BufferTools.checkEmpty(Seq()) must_== true
     }
   }
 
   "BufferTools.dropEmpty" should {
 
-    val buff0 = allocate(0)
-    val buff1 = allocate(1)
+    val buff0 = ByteBuffer.allocate(0)
+    val buff1 = ByteBuffer.allocate(1)
 
     "Find index of first Non-empty buffer" in {
       val arr1 = Array(buff0)
-      dropEmpty(arr1) must_== 0
+      BufferTools.dropEmpty(arr1) must_== 0
 
       val arr2 = Array(buff0, buff1)
-      dropEmpty(arr2) must_== 1
+      BufferTools.dropEmpty(arr2) must_== 1
 
       val arr3 = Array(buff1, buff0)
-      dropEmpty(arr3) must_== 0
+      BufferTools.dropEmpty(arr3) must_== 0
     }
 
     "drop empty buffers until the first non-empty buffer except the last" in {
       val arr = Array(buff0, buff0)
-      dropEmpty(arr) must_== 1
-      (arr(0) eq emptyBuffer) must_== true
+      BufferTools.dropEmpty(arr) must_== 1
+      (arr(0) eq BufferTools.emptyBuffer) must_== true
       (arr(1) eq buff0) must_== true
 
       val arr2 = Array(buff1, buff1)
-      dropEmpty(arr2) must_== 0
+      BufferTools.dropEmpty(arr2) must_== 0
       (arr2(0) eq buff1) must_== true
       (arr2(1) eq buff1) must_== true
 
       val arr3 = Array(buff0, buff1)
-      dropEmpty(arr3) must_== 1
-      (arr3(0) eq emptyBuffer) must_== true
+      BufferTools.dropEmpty(arr3) must_== 1
+      (arr3(0) eq BufferTools.emptyBuffer) must_== true
       (arr3(1) eq buff1) must_== true
     }
   }
 
+  "BufferTools.copyBuffers" should {
+
+    "copy a single buffer into a larger buffer" in {
+      val buffs = getBuffers(1)
+      val target = ByteBuffer.allocate(10)
+
+      BufferTools.copyBuffers(buffs, target) must_== 4
+      target.position() must_== 4
+      buffs(0).position() must_== 0
+    }
+
+    "copy a single buffer into a smaller buffer" in {
+      val buffs = getBuffers(1)
+      val target = ByteBuffer.allocate(2)
+
+      BufferTools.copyBuffers(buffs, target) must_== 2
+      target.position() must_== 2
+      buffs(0).position() must_== 0
+    }
+
+    "copy multiple buffers int a larger buffer" in {
+      val buffs = getBuffers(2)
+      val target = ByteBuffer.allocate(10)
+
+      BufferTools.copyBuffers(buffs, target) must_== 8
+      target.position() must_== 8
+
+      forall(buffs) { buff =>
+        buff.position() must_== 0
+      }
+    }
+
+    "copy multiple buffers int a smaller buffer" in {
+      val buffs = getBuffers(2)
+
+      {
+        val target = ByteBuffer.allocate(2)
+
+        BufferTools.copyBuffers(buffs, target) must_== 2
+        target.position() must_== 2
+
+        forall(buffs) { buff =>
+          buff.position() must_== 0
+        }
+      }
+
+      {
+        val target = ByteBuffer.allocate(6)
+
+        BufferTools.copyBuffers(buffs, target) must_== 6
+        target.position() must_== 6
+
+        forall(buffs) { buff =>
+          buff.position() must_== 0
+        }
+      }
+    }
+
+    "handle null buffers in the array" in {
+      val buffs = getBuffers(2)
+      buffs(0) = null
+
+      val target = ByteBuffer.allocate(10)
+
+      BufferTools.copyBuffers(buffs, target) must_== 4
+      target.position() must_== 4
+
+      buffs(1).position() must_== 0
+    }
+  }
+
+  "BufferTools.fastForwardBuffers" should {
+    "fast forward an entire array" in {
+      val buffers = getBuffers(4)
+
+      BufferTools.fastForwardBuffers(buffers, 4*4) must_== true
+      forall(buffers) { buffer =>
+        buffer.remaining must_== 0
+      }
+    }
+
+    "fast forward only part of an array" in {
+      val buffers = getBuffers(2)
+
+      BufferTools.fastForwardBuffers(buffers, 5) must_== true
+
+      buffers(0).remaining must_== 0
+      buffers(1).remaining must_== 3
+    }
+
+    "fast forward past an array" in {
+      val buffers = getBuffers(2)
+      BufferTools.fastForwardBuffers(buffers, 10) must_== false
+
+      forall(buffers){ buffer =>
+        buffer.remaining must_== 0
+      }
+    }
+
+    "fast forward an array with null elements" in {
+      val buffers = getBuffers(2)
+      buffers(0) = null
+
+      BufferTools.fastForwardBuffers(buffers, 2) must_== true
+
+      buffers(1).remaining must_== 2
+    }
+  }
+
+  "BufferTools.areDirectOrEmpty" should {
+    "Be true for a collection of direct buffers" in {
+      BufferTools.areDirectOrEmpty(getDirect(4)) must_== true
+    }
+
+    "Be true for a collection of nulls" in {
+      BufferTools.areDirectOrEmpty(Array[ByteBuffer](null, null)) must_== true
+    }
+
+    "Be true for a collection of direct buffers with a null element" in {
+      val buffs = getDirect(4)
+      buffs(3) = null
+      BufferTools.areDirectOrEmpty(buffs) must_== true
+    }
+
+    "Be false for a collection with a non-empty heap buffer in it" in {
+      val buffs = getDirect(4)
+      buffs(3) = ByteBuffer.allocate(4)
+      BufferTools.areDirectOrEmpty(buffs) must_== false
+    }
+
+    "Be true for a collection with an empty heap buffer in it" in {
+      val buffs = getDirect(4)
+      buffs(3) = ByteBuffer.allocate(0)
+      BufferTools.areDirectOrEmpty(buffs) must_== true
+    }
+  }
+
+  private def getBuffers(count: Int): Array[ByteBuffer] = getBuffersBase(count, false)
+
+  private def getDirect(count: Int): Array[ByteBuffer] = getBuffersBase(count, true)
+
+  private def getBuffersBase(count: Int, direct: Boolean): Array[ByteBuffer] = {
+    (0 until count).map { i =>
+      val buffer = if (direct) ByteBuffer.allocateDirect(4) else ByteBuffer.allocate(4)
+      buffer.putInt(4).flip()
+      buffer
+    }.toArray
+  }
 }


### PR DESCRIPTION
Problem

The java NIO implementation leaks direct memory because of the
way that it caches temporary direct ByteBuffers. This can lead
to OOM like errors.

Solution

Ensure that the scratch buffer is a direct ByteBuffer, and copy
heap buffers into it before writing, essentially stepping around
the logic that the JDK uses to write heap buffers.

Details

- Add additional allocation methods to BufferTools to be more
explicit.

- Use direct ByteBuffers for the scratch buffers in in NIO1 and NIO2
because they will most often be talking directly to the socket and
would necessitate a copy.

- Make tools for copying and fast forwarding ByteBuffers

- Fix the memory leak.

- Add a write loop so we saturate the tcp buffer without doing
excessive copies that are then discarded.

- Be awesome.