### PR TITLE
Add ability to configure channel options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ lazy val mimaSettings = Seq(
 /* dependencies */
 lazy val dependencies = Seq(
   libraryDependencies += specs2 % "test",
+  libraryDependencies += specs2Mock % "test",
   libraryDependencies += logbackClassic % "test",
   libraryDependencies += log4s
 )
@@ -123,6 +124,7 @@ lazy val twitterHPACK        = "com.twitter"                %  "hpack"          
 
 // Testing only dependencies
 lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "3.8.6"
+lazy val specs2Mock          = "org.specs2"                 %% "specs2-mock"         % specs2.revision
 lazy val asyncHttpClient     = "org.asynchttpclient"        %  "async-http-client"   % "2.0.24"
 
 

--- a/core/src/main/scala/org/http4s/blaze/channel/ChannelOptions.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ChannelOptions.scala
@@ -1,0 +1,23 @@
+package org.http4s.blaze.channel
+
+import java.net.SocketOption
+import java.nio.channels.NetworkChannel
+
+/** key-value pair composing a socket option */
+case class OptionValue[T](key: SocketOption[T], value: T)
+
+/** Collection of socket options */
+case class ChannelOptions(options: Vector[OptionValue[_]]) {
+  def applyToChannel(channel: NetworkChannel): Unit = {
+    options.foreach { case OptionValue(k, v) =>  channel.setOption(k, v) }
+  }
+}
+
+object ChannelOptions {
+  def apply(options: OptionValue[_]*): ChannelOptions =
+    ChannelOptions(options.toVector)
+
+  val DefaultOptions: ChannelOptions = apply(
+    OptionValue[java.lang.Boolean](java.net.StandardSocketOptions.TCP_NODELAY, true)
+  )
+}

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
@@ -1,10 +1,11 @@
 package org.http4s.blaze.channel.nio2
 
 import org.http4s.blaze.pipeline.HeadStage
-
 import java.nio.ByteBuffer
-import java.nio.channels.{CompletionHandler, AsynchronousSocketChannel, AsynchronousChannelGroup}
+import java.nio.channels.{AsynchronousChannelGroup, AsynchronousSocketChannel, CompletionHandler}
 import java.net.SocketAddress
+
+import org.http4s.blaze.channel.ChannelOptions
 
 import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
@@ -15,26 +16,31 @@ import scala.util.control.NonFatal
   * Provides a way to easily make TCP connections which can then serve as the Head for a pipeline
   *
   * @param bufferSize default buffer size to perform reads
-  * @param group the [[java.nio.channels.AsynchronousChannelGroup]] which will manage the connection
+  * @param group The [[java.nio.channels.AsynchronousChannelGroup]] which will manage the connection.
+  *              `None` will use the system default
   */
-class ClientChannelFactory(bufferSize: Int = 8*1024, group: AsynchronousChannelGroup = null) {
+final class ClientChannelFactory(
+    bufferSize: Int = DefaultBufferSize,
+    group: Option[AsynchronousChannelGroup] = None,
+    channelOptions: ChannelOptions = ChannelOptions.DefaultOptions) {
 
   def connect(remoteAddress: SocketAddress, bufferSize: Int = bufferSize): Future[HeadStage[ByteBuffer]] = {
     val p = Promise[HeadStage[ByteBuffer]]
 
     try {
-      val ch = AsynchronousSocketChannel.open(group)
+      val ch = AsynchronousSocketChannel.open(group.orNull)
       ch.connect(remoteAddress, null: Null, new CompletionHandler[Void, Null] {
         def failed(exc: Throwable, attachment: Null) {
           p.failure(exc)
         }
 
         def completed(result: Void, attachment: Null) {
+          channelOptions.applyToChannel(ch)
           p.success(new ByteBufferHead(ch, bufferSize = bufferSize))
         }
       })
     }
-    catch {case NonFatal(t) => p.tryFailure(t) }
+    catch { case NonFatal(t) => p.tryFailure(t) }
 
     p.future
   }

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/package.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/package.scala
@@ -1,0 +1,8 @@
+package org.http4s.blaze.channel
+
+package object nio2 {
+
+  /** Default buffer size use for IO operations */
+  private[nio2] val DefaultBufferSize: Int = 8*1024 // 8 KB
+
+}

--- a/core/src/test/scala/org/http4s/blaze/channel/ChannelOptionsSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/ChannelOptionsSpec.scala
@@ -1,0 +1,26 @@
+package org.http4s.blaze.channel
+
+import java.nio.channels.NetworkChannel
+
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class ChannelOptionsSpec extends Specification with Mockito {
+
+  "ChannelOptions" should {
+    "be set on a NetworkChannel" in {
+      val options = ChannelOptions(
+        OptionValue[java.lang.Boolean](java.net.StandardSocketOptions.TCP_NODELAY, true),
+        OptionValue[java.lang.Boolean](java.net.StandardSocketOptions.SO_KEEPALIVE, false)
+      )
+
+      val ch = mock[NetworkChannel]
+      ch.setOption(any, any) returns ch
+
+      options.applyToChannel(ch)
+
+      there was one(ch).setOption(java.net.StandardSocketOptions.TCP_NODELAY, java.lang.Boolean.TRUE)
+      there was one(ch).setOption(java.net.StandardSocketOptions.SO_KEEPALIVE, java.lang.Boolean.FALSE)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #46

Add `ChannelOptions`, a collection of ChannelOption->value pairs
that can be applied to a socket connection. These are passed to
the common vectors of socket generation to configure the socket
after its connected.

Also perform some minor API cleanup: make classes final, etc.