### PR TITLE
Add method `takeSlice` to BufferTools

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/util/BufferTools.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/BufferTools.scala
@@ -81,6 +81,26 @@ object BufferTools {
     }
   }
 
+  /** Take a slice of bytes from the `ByteBuffer`, consuming the bytes.
+    *
+    * @param buffer `ByteBuffer` to slice
+    * @param size number of bytes to slice. Must be less than or equal to the number of bytes remaining in `buffer`.
+    * @return the resulting view
+    */
+  def takeSlice(buffer: ByteBuffer, size: Int): ByteBuffer = {
+
+    if (size < 0 || size > buffer.remaining())
+      throw new IllegalArgumentException(s"Invalid size: $size. buffer: $buffer")
+
+    val currentLimit = buffer.limit()
+    buffer.limit(buffer.position() + size)
+    val slice = buffer.slice()
+
+    buffer.position(buffer.limit())
+      .limit(currentLimit)
+    slice
+  }
+
   /** Check the array of buffers to ensure they are all empty
     *
     * @param buffers `ByteBuffer`s to check for data

--- a/core/src/test/scala/org/http4s/blaze/util/BufferToolsSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/util/BufferToolsSpec.scala
@@ -66,6 +66,38 @@ class BufferToolsSpec extends Specification {
     }
   }
 
+  "BufferTools.takeSlice" should {
+    "Take a slice from a buffer" in {
+      val a = ByteBuffer.allocate(10)
+      a.putInt(123).putInt(456).flip()
+      a.remaining() must_== 8
+
+      val b = BufferTools.takeSlice(a, 4)
+
+      a.remaining must_== 4 // 4 bytes were consumed
+      a.getInt() must_== 456
+
+      b.remaining must_== 4
+      b.getInt() must_== 123
+    }
+
+    "throw an `IllegalArgumentException` if you try to slice too many bytes" in {
+      val a = ByteBuffer.allocate(10)
+      a.putInt(123).putInt(456).flip()
+      a.remaining() must_== 8
+
+      BufferTools.takeSlice(a, 10) must throwAn[IllegalArgumentException]
+    }
+
+    "throw an `IllegalArgumentException` if you try to slice negative bytes" in {
+      val a = ByteBuffer.allocate(10)
+      a.putInt(123).putInt(456).flip()
+      a.remaining() must_== 8
+
+      BufferTools.takeSlice(a, -4) must throwAn[IllegalArgumentException]
+    }
+  }
+
   "BufferTools.checkEmpty" should {
 
     "check if buffers are empty" in {

--- a/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
@@ -386,6 +386,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
                     final int buff_size = in.remaining();
 
                     if (remaining_chunk_size <= buff_size) {
+                        // End of this chunk
                         ByteBuffer result = submitPartialBuffer(in, (int)remaining_chunk_size);
                         _contentPosition = _chunkLength = 0;
                         _chunkState = ChunkState.CHUNK_LF;
@@ -426,6 +427,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
 
     /** Manages the buffer position while submitting the content -------- */
 
+    // TODO: do we care about these being `read-only`? It does ensure any underlying array is hidden...
     private ByteBuffer submitBuffer(ByteBuffer in) {
         ByteBuffer out = in.asReadOnlyBuffer();
         in.position(in.limit());
@@ -436,18 +438,9 @@ public abstract class BodyAndHeaderParser extends ParserBase {
         // Perhaps we are just right? Might be common.
         if (size == in.remaining()) {
             return submitBuffer(in);
+        } else {
+            return BufferTools.takeSlice(in, size).asReadOnlyBuffer();
         }
-
-        final int old_lim = in.limit();
-        final int end = in.position() + size;
-
-        // Make a slice buffer and return its read only image
-        in.limit(end);
-        ByteBuffer b = in.slice().asReadOnlyBuffer();
-        // fast forward our view of the data
-        in.limit(old_lim);
-        in.position(end);
-        return b;
     }
 
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http20/Http2Stage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/Http2Stage.scala
@@ -142,15 +142,12 @@ class Http2Stage private(nodeBuilder: Int => LeafBuilder[NodeMsg.Http2Msg],
         case Failure(t)  => onFailure(t, "processHandshake")
       }(Execution.trampoline)
     } else {
-      val l = buff.limit()
-      val p = buff.position()
-      buff.limit(p + clientTLSHandshakeString.length)
-      val header = UTF_8.decode(buff.slice()).toString()
+      val handshakeBuffer = BufferTools.takeSlice(buff, clientTLSHandshakeString.length)
+      val header = UTF_8.decode(handshakeBuffer).toString()
       logger.trace("Received header string: " + header)
 
       if (header == clientTLSHandshakeString) {
         logger.trace("Handshake complete. Entering readLoop")
-        buff.limit(l).position(p + clientTLSHandshakeString.length)
         decodeLoop(buff)
       } else {
         logger.info("HTTP/2.0: Failed to handshake, invalid header: " + header)

--- a/http/src/main/scala/org/http4s/blaze/http/http20/NodeMsgEncoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/NodeMsgEncoder.scala
@@ -9,9 +9,10 @@ import scala.annotation.tailrec
 import scala.collection.mutable.Buffer
 
 
-private[http20] class NodeMsgEncoder[HType](id: Int,
-                                      fencoder: Http20FrameEncoder,
-                                      hencoder: HeaderEncoder) {
+private[http20] class NodeMsgEncoder(
+    id: Int,
+    fencoder: Http20FrameEncoder,
+    hencoder: HeaderEncoder) {
 
   import NodeMsg.{ DataFrame, HeadersFrame }
 
@@ -95,7 +96,7 @@ private[http20] class NodeMsgEncoder[HType](id: Int,
   // Split the remaining header data into CONTINUATION frames.
   @tailrec
   private def mkContinuationFrames(maxPayload: Int, hBuff: ByteBuffer, acc: Buffer[ByteBuffer]): Unit = {
-    if (hBuff.remaining() >= maxPayload) {
+    if (hBuff.remaining() <= maxPayload) {
       acc ++= fencoder.mkContinuationFrame(id, true, hBuff)
     }
     else {

--- a/http/src/main/scala/org/http4s/blaze/http/http20/NodeMsgEncoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http20/NodeMsgEncoder.scala
@@ -3,6 +3,7 @@ package org.http4s.blaze.http.http20
 import java.nio.ByteBuffer
 
 import org.http4s.blaze.http.http20.NodeMsg.Http2Msg
+import org.http4s.blaze.util.BufferTools
 
 import scala.annotation.tailrec
 import scala.collection.mutable.Buffer
@@ -65,11 +66,10 @@ private[http20] class NodeMsgEncoder[HType](id: Int,
       acc ++= fencoder.mkHeaderFrame(hsBuff, id, hs.priority, true, hs.endStream, 0)
     } else {
       // need to split into HEADERS and CONTINUATION frames
-      val l = hsBuff.limit()
-      hsBuff.limit(hsBuff.position() + maxPayloadSize - priorityBytes)
-      acc ++= fencoder.mkHeaderFrame(hsBuff.slice(), id, hs.priority, false, hs.endStream, 0)
+      val headerBuffer = BufferTools.takeSlice(hsBuff, maxPayloadSize - priorityBytes)
+      acc ++= fencoder.mkHeaderFrame(headerBuffer, id, hs.priority, false, hs.endStream, 0)
+
       // Add the rest of the continuation frames
-      hsBuff.limit(l)
       mkContinuationFrames(maxPayloadSize, hsBuff, acc)
     }
   }
@@ -99,10 +99,8 @@ private[http20] class NodeMsgEncoder[HType](id: Int,
       acc ++= fencoder.mkContinuationFrame(id, true, hBuff)
     }
     else {
-      val l = hBuff.limit()
-      hBuff.limit(hBuff.position() + maxPayload)
-      acc ++= fencoder.mkContinuationFrame(id, false, hBuff.slice())
-      hBuff.limit(l)
+      val thisBuffer = BufferTools.takeSlice(hBuff, maxPayload)
+      acc ++= fencoder.mkContinuationFrame(id, false, thisBuffer)
       mkContinuationFrames(maxPayload, hBuff, acc)
     }
 

--- a/http/src/test/scala/org/http4s/blaze/http/http20/NodeMsgEncoderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http20/NodeMsgEncoderSpec.scala
@@ -1,0 +1,117 @@
+package org.http4s.blaze.http.http20
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.http20.NodeMsg.{DataFrame, HeadersFrame}
+import org.http4s.blaze.util.BufferTools
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+import scala.collection.mutable.ArrayBuffer
+
+
+class NodeMsgEncoderSpec extends Specification with Mockito {
+
+  private def headerEncoder(): HeaderEncoder = new HeaderEncoder()
+
+  private def getMockFrameEncoder(): Http20FrameEncoder = mock[Http20FrameEncoder]
+
+  val fourBytes = Array[Byte](1,2,3,4)
+
+  "NodeMessageEncoder" should {
+
+    // TODO: respect byte boundaries
+
+    "Encode a DataFrame" in {
+      val mockFrameEnc = getMockFrameEncoder()
+
+      val theseBuffers = List(BufferTools.emptyBuffer)
+
+      mockFrameEnc.mkDataFrame(any/*buffer*/, any /*streamid*/, any /*isLast*/, any /*padding*/) returns theseBuffers
+
+      val encoder = new NodeMsgEncoder(1, mockFrameEnc, headerEncoder())
+
+      val data = DataFrame(true, ByteBuffer.wrap(fourBytes))
+      val out = new ArrayBuffer[ByteBuffer]()
+
+      val (flow, unused) = encoder.encodeMessages(Int.MaxValue, Int.MaxValue, Seq(data), out)
+
+      unused.isEmpty must_== true
+      flow must_== 4
+      out.toList must_== theseBuffers
+      there was one(mockFrameEnc).mkDataFrame(ByteBuffer.wrap(fourBytes), 1, true, 0)
+    }
+
+    "Encode a HeadersFrame" in {
+      val mockFrameEnc = getMockFrameEncoder()
+
+      val theseBuffers = List(BufferTools.emptyBuffer)
+
+      mockFrameEnc.mkHeaderFrame(
+        any, // headerData
+        any, // streamId
+        any, // priority
+        any, // endHeaders
+        any, // endStream
+        any  // padding
+      ) returns theseBuffers
+
+      val encoder = new NodeMsgEncoder(1, mockFrameEnc, headerEncoder())
+
+      val hs = Seq("a" -> "a", "b" -> "b")
+      val data = HeadersFrame(None, true, hs)
+      val out = new ArrayBuffer[ByteBuffer]()
+
+      val (flow, unused) = encoder.encodeMessages(Int.MaxValue, Int.MaxValue, Seq(data), out)
+
+      unused.isEmpty must_== true
+      flow must_== 0
+      out.toList must_== theseBuffers
+
+      val expectedBuffer = headerEncoder().encodeHeaders(hs)
+
+      there was one(mockFrameEnc).mkHeaderFrame(expectedBuffer, 1, None, true, true, 0)
+    }
+
+    "Encode a HeadersFrame that exceeds the max frame size" in {
+      val mockFrameEnc = getMockFrameEncoder()
+
+      val theseBuffers = List(BufferTools.emptyBuffer)
+      val thoseBuffers = List(ByteBuffer.wrap(fourBytes))
+
+      mockFrameEnc.mkHeaderFrame(
+        any, // headerData
+        any, // streamId
+        any, // priority
+        any, // endHeaders
+        any, // endStream
+        any  // padding
+      ) returns theseBuffers
+
+      mockFrameEnc.mkContinuationFrame(
+        any, // streamId
+        any, // endHeaders
+        any  // buffer
+      ) returns thoseBuffers
+
+      val encoder = new NodeMsgEncoder(1, mockFrameEnc, headerEncoder())
+
+      val hs = Seq("a" -> "a", "b" -> "b")
+      val expectedBuffer = headerEncoder().encodeHeaders(hs)
+
+      val data = HeadersFrame(None, true, hs)
+      val out = new ArrayBuffer[ByteBuffer]()
+
+      val (flow, unused) = encoder.encodeMessages(expectedBuffer.remaining() - 1, Int.MaxValue, Seq(data), out)
+
+      unused.isEmpty must_== true
+      flow must_== 0
+      out.toList must_== (theseBuffers ++ thoseBuffers)
+
+      val firstChunk = BufferTools.takeSlice(expectedBuffer, expectedBuffer.remaining() - 1)
+
+      there was one(mockFrameEnc).mkHeaderFrame(firstChunk, 1, None, false, true, 0)
+      there was one(mockFrameEnc).mkContinuationFrame(1, true, expectedBuffer)
+    }
+  }
+}


### PR DESCRIPTION
`takeSlice(ByteBuffer, Int)` makes it easier to deal
with framed content by allow one to easily slice away
a sub-buffer.

This exposed a problem encoding header continuation
frames: an oversized HEADERS frame was not split correctly,
so it was fixed and some tests added.