### PR TITLE
Fix infinite loop on ssl handshake failure

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/util/package.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/package.scala
@@ -1,0 +1,7 @@
+package org.http4s.blaze
+
+package object util {
+  /** Constructs an assertion error with a reference back to our issue tracker. Use only with head hung low. */
+  private[blaze] def bug(message: String): AssertionError =
+    new AssertionError(s"This is a bug. Please report to https://github.com/http4s/blaze/issues: ${message}")
+}


### PR DESCRIPTION
Fixes #75

If the handshake fails the SSLEngine.unwrap(..) call will result in a
status of CLOSED but we don't check that case and just continue the
loop. Forever.

Thanks @tanaka-de-silva for reporting and @svalaskevicius helping diagnose!