### PR TITLE
Fix a race condition in ServerChannel

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/ServerChannel.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ServerChannel.scala
@@ -1,67 +1,114 @@
 package org.http4s.blaze.channel
 
-
 import java.io.Closeable
 import java.net.InetSocketAddress
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicReference
-
-import scala.annotation.tailrec
-import scala.util.control.NonFatal
-
 import org.log4s.getLogger
+import org.http4s.blaze.util.Execution
+import scala.util.control.NonFatal
+import scala.concurrent.ExecutionContext
 
 /** Representation of a bound server */
 abstract class ServerChannel extends Closeable { self =>
+  import ServerChannel.State._
+
   protected val logger = getLogger
 
-  private val shutdownHooks = new AtomicReference[Vector[()=> Unit]](Vector.empty)
+  private var state: State = Open
+
+  private val shutdownHooks = new scala.collection.mutable.Queue[Hook]
 
   /** Close out any resources associated with the [[ServerChannel]] */
   protected def closeChannel(): Unit
 
-  /** Close the [[ServerChannel]] and execute any shutdown hooks */
+  /** The bound socket address for this [[ServerChannel]] */
+  def socketAddress: InetSocketAddress
+
+  /** Close the [[ServerChannel]] and execute any shutdown hooks
+    *
+    * @note this method is idempotent
+    */
   final def close(): Unit = {
-    closeChannel()
-    runShutdownHooks()
+    val run = shutdownHooks.synchronized {
+      if (state != Open) false
+      else {
+        state = Closing
+        // Need to close the channel, get all the hooks, then notify the listeners
+        closeChannel()
+        true
+      }
+    }
+
+    // We move this outside of the lock to ensure that we don't schedule work
+    // inside the lock since the EC could run the task immediately.
+    if (run) scheduleHook()
   }
 
-  /** Wait for this server channel to close */
-  final def join(): Unit = {
-    val l = new CountDownLatch(1)
-
-    if (!addShutdownHook(() => l.countDown()))
-      l.countDown()
-
-    l.await()
+  /** Wait for this server channel to close, including execution of all successfully
+    * registered shutdown hooks.
+    */
+  final def join(): Unit = shutdownHooks.synchronized {
+    while (state != Closed) {
+      shutdownHooks.wait()
+    }
   }
 
   /** Add code to be executed when the [[ServerChannel]] is closed
     *
     * @param f hook to execute on shutdown
-    * @return true if the hook was successfully registered, false otherwise
+    * @return true if the hook was successfully registered, false otherwise.
     */
-  final def addShutdownHook(f: () => Unit): Boolean = {
-    @tailrec
-    def go(): Boolean = shutdownHooks.get() match {
-      case null                                                     => false
-      case hooks if(shutdownHooks.compareAndSet(hooks, hooks :+ f)) => true
-      case _                                                        => go()
-    }
-
-    go()
-  }
-
-  private def runShutdownHooks(): Unit = {
-    val hooks = shutdownHooks.getAndSet(null)
-    if (hooks != null) {
-      hooks.foreach { f =>
-        try f()
-        catch { case NonFatal(t) => logger.error(t)(s"Exception occurred during Channel shutdown.") }
+  final def addShutdownHook(f: () => Unit)(implicit ec: ExecutionContext = Execution.directec): Boolean = {
+    shutdownHooks.synchronized {
+      if (state != Open) false
+      else {
+        shutdownHooks += Hook(f, ec)
+        true
       }
     }
   }
 
-  /* Return the bound socket address for this server channel */
-  def socketAddress: InetSocketAddress
+  // Checks if we have a hook, and if we do, schedule it and then check again
+  private[this] def scheduleHook(): Unit = {
+    val hook = shutdownHooks.synchronized {
+      if (shutdownHooks.nonEmpty) Some(shutdownHooks.dequeue())
+      else {
+        // all our hooks are done! Switch to closed state, notify
+        // all the listeners
+        state = Closed
+        shutdownHooks.notifyAll()
+        None
+      }
+    }
+    hook match {
+      case Some(hook) => hook.ec.execute(new HookRunnable(hook.task))
+      case None => ()
+    }
+  }
+
+  private case class Hook(task: () => Unit, ec: ExecutionContext)
+
+  // Bundles the task of executing a hook and scheduling the next hook
+  private[this] class HookRunnable(hook: () => Unit) extends Runnable {
+    override def run(): Unit = {
+      try hook()
+      catch {
+        case NonFatal(t) =>
+          logger.error(t)(s"Exception occurred during Channel shutdown.")
+      }
+      finally {
+        // We bounce these through the thread local trampoline to ensure
+        // that we don't get a SOE if everyone is using the direct EC.
+        Execution.trampoline.execute(new Runnable {
+          override def run(): Unit = scheduleHook()
+        })
+      }
+    }
+  }
+}
+
+private object ServerChannel {
+  object State extends Enumeration {
+    type State = Value
+    val Open, Closing, Closed = Value
+  }
 }

--- a/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
@@ -17,7 +17,7 @@ class ChannelSpec extends Specification {
       val factory = if (nio2) NIO2SocketServerGroup.fixedGroup(workerThreads = 2)
                     else      NIO1SocketServerGroup.fixedGroup(workerThreads = 2)
 
-      (factory,factory.bind(address, f).getOrElse(sys.error("Failed to initialize socket at address " + address)))
+      (factory, factory.bind(address, f).getOrElse(sys.error("Failed to initialize socket at address " + address)))
     }
   }
 


### PR DESCRIPTION
When calling ServerChannel.join(), its not clear that tasks may not be
finished executing before the call returns because it's up to the caller
of `close()` to execute all the tasks.

We fix this by making `join()` wait until all tasks have been executed
before returning. To improve the user experience, we also allow passing
an `ExecutionContext` on which to run the shutdown hooks.