### PR TITLE
Add BodyReader and ALPNTokens

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -2,7 +2,6 @@ package org.http4s.blaze.channel.nio1
 
 
 import org.http4s.blaze.pipeline.{Command => Cmd}
-import org.http4s.blaze.util.BufferTools
 import org.http4s.blaze.pipeline._
 import org.http4s.blaze.channel.BufferPipelineBuilder
 

--- a/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
@@ -87,6 +87,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
         return _hstate == HeaderState.END;
     }
 
+    /** Determine if the parser is in a state that is guarenteed to not produce any more body content */
     public final boolean contentComplete() {
         return mustNotHaveBody() ||
             _endOfContent == EndOfContent.END ||
@@ -386,6 +387,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
                     final int buff_size = in.remaining();
 
                     if (remaining_chunk_size <= buff_size) {
+                        // End of this chunk
                         ByteBuffer result = submitPartialBuffer(in, (int)remaining_chunk_size);
                         _contentPosition = _chunkLength = 0;
                         _chunkState = ChunkState.CHUNK_LF;
@@ -426,6 +428,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
 
     /** Manages the buffer position while submitting the content -------- */
 
+    // TODO: do we care about these being `read-only`? It does ensure any underlying array is hidden...
     private ByteBuffer submitBuffer(ByteBuffer in) {
         ByteBuffer out = in.asReadOnlyBuffer();
         in.position(in.limit());
@@ -436,18 +439,9 @@ public abstract class BodyAndHeaderParser extends ParserBase {
         // Perhaps we are just right? Might be common.
         if (size == in.remaining()) {
             return submitBuffer(in);
+        } else {
+            return BufferTools.takeSlice(in, size).asReadOnlyBuffer();
         }
-
-        final int old_lim = in.limit();
-        final int end = in.position() + size;
-
-        // Make a slice buffer and return its read only image
-        in.limit(end);
-        ByteBuffer b = in.slice().asReadOnlyBuffer();
-        // fast forward our view of the data
-        in.limit(old_lim);
-        in.position(end);
-        return b;
     }
 
 }

--- a/http/src/main/scala/org/http4s/blaze/http/ALPNTokens.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/ALPNTokens.scala
@@ -1,0 +1,10 @@
+package org.http4s.blaze.http
+
+private object ALPNTokens {
+  // protocol strings for known HTTP implementations
+  val HTTP_1_1 = "http/1.1"
+  val H2       = "h2"
+  val H2_14    = "h2-14"
+
+  val AllTokens: Seq[String] = Seq(HTTP_1_1, H2, H2_14)
+}

--- a/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
@@ -1,0 +1,125 @@
+package org.http4s.blaze.http
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.util.{BufferTools, Execution}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
+
+/** Representation of a HTTP message body
+  *
+  * @note The release of resources must be idempotent, meaning that `discard()` may
+  *       be called after complete consumption of the body and it may also be called
+  *       numerous times.
+  */
+trait BodyReader {
+
+  /** Throw away this `MessageBody` */
+  def discard(): Unit
+
+  /** Get a `Future` which may contain message body data.
+    *
+    * If no data remains, the `ByteBuffer` will be empty as defined by `ByteBuffer.hasRemaining()`
+    */
+  def apply(): Future[ByteBuffer]
+
+  /** Examine whether the `MessageBody` may yield additional data.
+    *
+    * This may be a result of being discarded, failure, or deletion of the data stream.
+    *
+    * Because `MessageBody` is async it is not, in general, possible to definitively determine
+    * if more data remains in the stream. Therefore, the contract of this method is that a return
+    * value of `true` guarantees that no more data can be obtained from this `MessageBody`, but a
+    * return value of `false` does not guarantee more data.
+    */
+  def isEmpty: Boolean
+
+  /** Accumulate any remaining data.
+    *
+    * The remainder of the message body will be accumulated into a single buffer. If no data remains,
+    * the `ByteBuffer` will be empty as defined by `ByteBuffer.hasRemaining()`
+    *
+    * @param max maximum bytes to accumulate before resulting in a failed future with the exception
+    *            `MessageBody.BodyReaderOverflowException`.
+    */
+  def accumulate(max: Int = Int.MaxValue): Future[ByteBuffer] =
+    BodyReader.accumulate(max, this)
+}
+
+private object BodyReader {
+
+  final class BodyReaderOverflowException(val max: Int, val accumulated: Long)
+    extends Exception(s"Message body overflowed. Maximum permitted: $max, accumulated: $accumulated")
+
+  /** The canonical empty [[BodyReader]]
+    *
+    * This should be the instance you use if you want to signal that the message body is
+    * in guaranteed to be empty.
+    */
+  val EmptyBodyReader: BodyReader = new BodyReader {
+    override def discard(): Unit = ()
+    override def apply(): Future[ByteBuffer] = BufferTools.emptyFutureBuffer
+    override def isEmpty: Boolean = true
+  }
+
+  /** Construct a [[BodyReader]] with exactly one chunk of data
+    *
+    * This method takes ownership if the passed `ByteBuffer`: any changes to the underlying
+    * buffer will be visible to the consumer of this `MessageBody` and vise versa.
+    *
+    * @note if the passed buffer is empty, the `EmptyBodyReader` is returned.
+    */
+  def singleBuffer(buffer: ByteBuffer): BodyReader = {
+    if (!buffer.hasRemaining) EmptyBodyReader
+    else new BodyReader {
+      private[this] var buff = buffer
+
+      override def discard(): Unit = this.synchronized {
+        buff = BufferTools.emptyBuffer
+      }
+
+      override def isEmpty: Boolean = this.synchronized { !buff.hasRemaining }
+
+      override def apply(): Future[ByteBuffer] = this.synchronized {
+        if (buff.hasRemaining) {
+          val b = buff
+          buff = BufferTools.emptyBuffer
+          Future.successful(b)
+        }
+        else BufferTools.emptyFutureBuffer
+      }
+    }
+  }
+
+  /** The remainder of the message body will be accumulated into a single buffer. If no data remains,
+    * the `ByteBuffer` will be empty as defined by `ByteBuffer.hasRemaining()`
+    */
+  def accumulate(max: Int, body: BodyReader): Future[ByteBuffer] = {
+    require(max >= 0)
+
+    val acc = new ArrayBuffer[ByteBuffer]
+    val p = Promise[ByteBuffer]
+
+    def go(bytes: Long): Unit = {
+      body().onComplete {
+        case Success(buff) if buff.hasRemaining() =>
+          val accumulated = bytes + buff.remaining()
+          if (accumulated <= max) {
+            acc += buff
+            go(accumulated)
+          }
+          else p.tryFailure(new BodyReaderOverflowException(max, accumulated))
+
+        case Success(_) =>
+          p.trySuccess(BufferTools.joinBuffers(acc))
+
+        case f@Failure(_) => p.tryComplete(f)
+      }(Execution.trampoline)
+    }
+    go(0)
+
+    p.future
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
@@ -34,7 +34,7 @@ trait BodyReader {
     * value of `true` guarantees that no more data can be obtained from this `MessageBody`, but a
     * return value of `false` does not guarantee more data.
     */
-  def isEmpty: Boolean
+  def isExhausted: Boolean
 
   /** Accumulate any remaining data.
     *
@@ -61,13 +61,13 @@ private object BodyReader {
   val EmptyBodyReader: BodyReader = new BodyReader {
     override def discard(): Unit = ()
     override def apply(): Future[ByteBuffer] = BufferTools.emptyFutureBuffer
-    override def isEmpty: Boolean = true
+    override def isExhausted: Boolean = true
   }
 
   /** Construct a [[BodyReader]] with exactly one chunk of data
     *
     * This method takes ownership if the passed `ByteBuffer`: any changes to the underlying
-    * buffer will be visible to the consumer of this `MessageBody` and vise versa.
+    * buffer will be visible to the consumer of this `MessageBody` and vice versa.
     *
     * @note if the passed buffer is empty, the `EmptyBodyReader` is returned.
     */
@@ -80,7 +80,7 @@ private object BodyReader {
         buff = BufferTools.emptyBuffer
       }
 
-      override def isEmpty: Boolean = this.synchronized { !buff.hasRemaining }
+      override def isExhausted: Boolean = this.synchronized { !buff.hasRemaining }
 
       override def apply(): Future[ByteBuffer] = this.synchronized {
         if (buff.hasRemaining) {

--- a/http/src/test/scala/org/http4s/blaze/http/BodyReaderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/BodyReaderSpec.scala
@@ -1,0 +1,91 @@
+package org.http4s.blaze.http
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.BodyReader.BodyReaderOverflowException
+import org.http4s.blaze.util.BufferTools
+import org.specs2.mutable.Specification
+
+import scala.concurrent.{Await, Awaitable, Future}
+import scala.concurrent.duration._
+
+class BodyReaderSpec extends Specification {
+
+  def await[T](a: Awaitable[T]): T =
+    Await.result(a, 5.seconds)
+
+  "BodyReader.singleBuffer" should {
+    "Return the empty reader if the buffer is empty" in {
+      val reader = BodyReader.singleBuffer(ByteBuffer.allocate(0))
+      reader.isEmpty must beTrue
+    }
+
+    "Provide the buffer on first invocation" in {
+      val buf = ByteBuffer.allocate(10)
+      val reader = BodyReader.singleBuffer(buf)
+      reader.isEmpty must beFalse
+
+      await(reader()) must_== buf
+      reader.isEmpty must beTrue
+    }
+
+    "discard clears the buffer" in {
+      val buf = ByteBuffer.allocate(10)
+      val reader = BodyReader.singleBuffer(buf)
+      reader.discard()
+      reader.isEmpty must beTrue
+      await(reader()).hasRemaining must beFalse
+    }
+
+  }
+
+  "BodyReader.accumulate(max, bodyReader)" should {
+    "accumulate an empty buffer" in {
+      val reader = BodyReader.singleBuffer(ByteBuffer.allocate(0))
+      val bytes = await(BodyReader.accumulate(Int.MaxValue, reader))
+      bytes.remaining() must_== 0
+    }
+
+    "accumulate a single buffer" in {
+      val reader = BodyReader.singleBuffer(ByteBuffer.allocate(10))
+      val bytes = await(BodyReader.accumulate(Int.MaxValue, reader))
+      bytes.remaining() must_== 10
+    }
+
+    "accumulate multiple buffers" in {
+      val reader = new MultiByteReader(
+        ByteBuffer.allocate(10),
+        ByteBuffer.allocate(1)
+      )
+
+      val bytes = await(BodyReader.accumulate(Int.MaxValue, reader))
+      bytes.remaining() must_== 11
+    }
+
+    "not overflow on allowed bytes" in {
+      val ByteCount = 10
+      val reader = BodyReader.singleBuffer(ByteBuffer.allocate(ByteCount))
+      val bytes = await(BodyReader.accumulate(ByteCount, reader))
+      bytes.remaining() must_== ByteCount
+    }
+
+    "not allow overflow" in {
+      val reader = BodyReader.singleBuffer(ByteBuffer.allocate(10))
+      await(BodyReader.accumulate(9, reader)) must throwA[BodyReaderOverflowException]
+    }
+  }
+
+  private class MultiByteReader(data: ByteBuffer*) extends BodyReader {
+    private val buffers = new scala.collection.mutable.Queue[ByteBuffer]
+    buffers ++= data
+
+    override def discard(): Unit = synchronized { buffers.clear() }
+
+    override def apply(): Future[ByteBuffer] = synchronized {
+      if (!isEmpty) Future.successful(buffers.dequeue())
+      else Future.successful(BufferTools.emptyBuffer)
+    }
+
+    override def isEmpty: Boolean = synchronized { buffers.isEmpty }
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/BodyReaderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/BodyReaderSpec.scala
@@ -17,23 +17,23 @@ class BodyReaderSpec extends Specification {
   "BodyReader.singleBuffer" should {
     "Return the empty reader if the buffer is empty" in {
       val reader = BodyReader.singleBuffer(ByteBuffer.allocate(0))
-      reader.isEmpty must beTrue
+      reader.isExhausted must beTrue
     }
 
     "Provide the buffer on first invocation" in {
       val buf = ByteBuffer.allocate(10)
       val reader = BodyReader.singleBuffer(buf)
-      reader.isEmpty must beFalse
+      reader.isExhausted must beFalse
 
       await(reader()) must_== buf
-      reader.isEmpty must beTrue
+      reader.isExhausted must beTrue
     }
 
     "discard clears the buffer" in {
       val buf = ByteBuffer.allocate(10)
       val reader = BodyReader.singleBuffer(buf)
       reader.discard()
-      reader.isEmpty must beTrue
+      reader.isExhausted must beTrue
       await(reader()).hasRemaining must beFalse
     }
 
@@ -82,10 +82,10 @@ class BodyReaderSpec extends Specification {
     override def discard(): Unit = synchronized { buffers.clear() }
 
     override def apply(): Future[ByteBuffer] = synchronized {
-      if (!isEmpty) Future.successful(buffers.dequeue())
+      if (!isExhausted) Future.successful(buffers.dequeue())
       else Future.successful(BufferTools.emptyBuffer)
     }
 
-    override def isEmpty: Boolean = synchronized { buffers.isEmpty }
+    override def isExhausted: Boolean = synchronized { buffers.isEmpty }
   }
 }


### PR DESCRIPTION
BodyReader is going to be the core abstraction for extracting data from
a HTTP message body and ALPNTokens are going to be necessary for
performing ALPN negotiation between HTTP/1.x and HTTP/2.