### PR TITLE
Bump to http4s-websocket-0.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val dependencies = Seq(
 )
 
 lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "3.8.6"
-lazy val http4sWebsocket     = "org.http4s"                 %% "http4s-websocket"    % "0.1.6"
+lazy val http4sWebsocket     = "org.http4s"                 %% "http4s-websocket"    % "0.2.0"
 lazy val logbackClassic      = "ch.qos.logback"             %  "logback-classic"     % "1.1.3"
 lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.3.3"
 lazy val scalaXml =            "org.scala-lang.modules"     %% "scala-xml"           % "1.0.5"


### PR DESCRIPTION
MiMa says it's binary compatible. This will eliminate an irritating eviction warning on http4s >= 0.16 if we release this as 0.12.7, and bump blaze in http4s.

/cc @ZizhengTai @cquiroz