### PR TITLE
Add pooled ClientSessionManagerImpl

### DIFF
--- a/examples/src/main/scala/org/http4s/blaze/examples/ClientExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/ClientExample.scala
@@ -1,0 +1,35 @@
+package org.http4s.blaze.examples
+
+import org.http4s.blaze.http.{ClientResponse, HttpClient}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object ClientExample {
+
+  lazy val client = HttpClient.pooledHttpClient
+
+  val requests = Seq(
+    "https://www.google.com",
+    "https://github.com",
+    "http://http4s.org",
+    "https://www.google.com/search?client=ubuntu&channel=fs&q=fish&ie=utf-8&oe=utf-8"
+  )
+
+  def main(args: Array[String]): Unit = {
+
+    val fs = (requests ++ requests).map { url =>
+      val r = client.GET(url){ response =>
+        println(s"Status: ${response.status}")
+        ClientResponse.stringBody(response)
+      }
+
+      Thread.sleep(500) // give the h2 sessions time to materialize
+      r
+    }
+
+    val bodies = Await.result(Future.sequence(fs), 5.seconds)
+    println(s"Read ${bodies.foldLeft(0)(_ + _.length)} bytes from ${bodies.length} requests")
+  }
+}

--- a/examples/src/main/scala/org/http4s/blaze/examples/ExampleKeystore.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/ExampleKeystore.scala
@@ -1,7 +1,7 @@
 package org.http4s.blaze.examples
 
 import java.security.KeyStore
-import javax.net.ssl.{TrustManagerFactory, KeyManagerFactory, SSLContext}
+import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
 
 import org.http4s.blaze.util.BogusKeystore
 

--- a/http/src/main/scala/org/http4s/blaze/http/ClientSessionManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/ClientSessionManagerImpl.scala
@@ -1,0 +1,167 @@
+package org.http4s.blaze.http
+
+import org.http4s.blaze.channel.nio2.ClientChannelFactory
+import org.http4s.blaze.http.ClientSessionManagerImpl._
+import org.http4s.blaze.http.HttpClientSession.{Closed, ReleaseableResponse, Status}
+import org.http4s.blaze.http.http1.client.Http1ClientStage
+import org.http4s.blaze.http.util.UrlTools.UrlComposition
+import org.http4s.blaze.pipeline.stages.SSLStage
+import org.http4s.blaze.pipeline.{Command, LeafBuilder}
+import org.http4s.blaze.util.Execution
+import org.log4s.getLogger
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Future, Promise}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
+
+private object ClientSessionManagerImpl {
+  case class ConnectionId(scheme: String, authority: String)
+
+  case class Http1SessionProxy(id: ConnectionId, parent: Http1ClientSession) extends Http1ClientSession {
+    override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = parent.dispatch(request)
+    override def status: Status = parent.status
+    override def close(within: Duration): Future[Unit] = parent.close(within)
+  }
+
+  def apply(config: HttpClientConfig): ClientSessionManagerImpl = {
+    val sessionCache = new java.util.HashMap[ConnectionId, java.util.Collection[HttpClientSession]]
+    new ClientSessionManagerImpl(sessionCache, config)
+  }
+}
+
+private final class ClientSessionManagerImpl(sessionCache: java.util.Map[ConnectionId, java.util.Collection[HttpClientSession]], config: HttpClientConfig) extends ClientSessionManager {
+
+  private[this] def getId(composition: UrlComposition): ConnectionId =
+    ConnectionId(composition.scheme, composition.authority)
+
+  private[this] implicit def ec = Execution.trampoline
+
+  private[this] val logger = getLogger
+  private[this] val socketFactory = new ClientChannelFactory(group = config.channelGroup)
+
+  override def acquireSession(request: HttpRequest): Future[HttpClientSession] = {
+    logger.debug(s"Acquiring session for request $request")
+     UrlComposition(request.url) match {
+      case Success(urlComposition) =>
+        val id = getId(urlComposition)
+        val session = findExistingSession(id)
+
+        if (session == null) createNewSession(urlComposition, id)
+        else {
+          logger.debug(s"Found hot session for id $id: $session")
+          Future.successful(session)
+        }
+
+      case Failure(t) => Future.failed(t)
+    }
+  }
+
+  // WARNING: can emit `null`. For internal use only
+  private[this] def findExistingSession(id: ConnectionId): HttpClientSession = sessionCache.synchronized {
+    sessionCache.get(id) match {
+      case null => null // nop
+      case sessions =>
+        var session: HttpClientSession = null
+        val it = sessions.iterator
+        while(session == null && it.hasNext) it.next() match {
+          case h2: Http2ClientSession if h2.status == Closed =>
+            h2.closeNow() // make sure its closed
+            it.remove()
+
+          case h2: Http2ClientSession if h2.quality > 0.1 =>
+            session = h2
+
+          case _: Http2ClientSession => () // nop
+
+          case h1: Http1ClientSession =>
+            it.remove()
+            if (h1.status != Closed) { // Should never be busy
+              session = h1 // found a suitable HTTP/1.x session.
+            }
+        }
+
+        // if we took the last session, drop the collection
+        if (sessions.isEmpty) {
+          sessionCache.remove(id)
+        }
+
+        session
+    }
+  }
+
+  private[this] def createNewSession(urlComposition: UrlComposition, id: ConnectionId): Future[HttpClientSession] = {
+    logger.debug(s"Creating new session for id $id")
+    val p = Promise[HttpClientSession]
+
+    socketFactory.connect(urlComposition.getAddress).onComplete {
+      case Failure(e) => p.tryFailure(e)
+      case Success(head) =>
+        val clientStage = new Http1ClientStage(config)
+        var builder = LeafBuilder(clientStage)
+        if (urlComposition.scheme == "https") {
+          val engine = config.getClientSslEngine()
+          engine.setUseClientMode(true)
+          builder = builder.prepend(new SSLStage(engine))
+        }
+
+        builder.base(head)
+        head.sendInboundCommand(Command.Connected)
+        p.trySuccess(new Http1SessionProxy(id, clientStage))
+      }
+
+    p.future
+  }
+
+  /** Return the session to the pool.
+    *
+    * Depending on the state of the session and the nature of the pool, this may
+    * either cache the session for future use or close it.
+    */
+  override def returnSession(session: HttpClientSession): Unit = {
+    logger.debug(s"Returning session $session")
+    session match {
+      case _ if session.isClosed => () // nop
+      case _: Http2ClientSession => () // nop
+      case h1: Http1ClientSession if !h1.isReady =>
+        logger.debug(s"Closing unready session $h1")
+        h1.closeNow() // we just orphan the Future. Don't care.
+        ()
+
+      case proxy: Http1SessionProxy => addSessionToCache(proxy.id, proxy)
+      case other => sys.error("The impossible happened!")
+    }
+  }
+
+  /** Close the `SessionManager` and free any resources */
+  override def close(): Future[Unit] = {
+    logger.debug(s"Closing session")
+    sessionCache.synchronized {
+      sessionCache.asScala.values.foreach(_.asScala.foreach { session =>
+        try session.closeNow()
+        catch { case NonFatal(t) =>
+          logger.warn(t)("Exception caught while closing session")
+        }
+      })
+      sessionCache.clear()
+    }
+    Future.successful(())
+  }
+
+  private[this] def addSessionToCache(id: ConnectionId, session: HttpClientSession): Unit = {
+    val size = sessionCache.synchronized {
+      val collection = sessionCache.get(id) match {
+        case null =>
+          val stack = new java.util.Stack[HttpClientSession]()
+          sessionCache.put(id, stack)
+          stack
+        case some => some
+      }
+
+      collection.add(session)
+      collection.size
+    }
+    logger.debug(s"Added session $session. Now ${size} sessions for id $id")
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/ClientSessionManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/ClientSessionManagerImpl.scala
@@ -100,7 +100,7 @@ private final class ClientSessionManagerImpl(sessionCache: java.util.Map[Connect
       case Success(head) =>
         val clientStage = new Http1ClientStage(config)
         var builder = LeafBuilder(clientStage)
-        if (urlComposition.scheme == "https") {
+        if (urlComposition.scheme.equalsIgnoreCase("https")) {
           val engine = config.getClientSslEngine()
           engine.setUseClientMode(true)
           builder = builder.prepend(new SSLStage(engine))
@@ -130,7 +130,7 @@ private final class ClientSessionManagerImpl(sessionCache: java.util.Map[Connect
         ()
 
       case proxy: Http1SessionProxy => addSessionToCache(proxy.id, proxy)
-      case other => sys.error("The impossible happened!")
+      case other => sys.error(s"The impossible happened! Found invalid type: $other")
     }
   }
 

--- a/http/src/main/scala/org/http4s/blaze/http/HttpClient.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/HttpClient.scala
@@ -26,7 +26,7 @@ trait HttpClient extends ClientActions {
     * @param request request to dispatch
     * @return the response. The cleanup of the resources associated with
     *         this dispatch are tied to the [[BodyReader]] of the [[ClientResponse]].
-    *         Release of resources is triggered by complete consumption of the [[BodyReader]]
+    *         Release of resources is triggered by complete consumption of the `MessageBody`
     *         or by calling `MessageBody.discard()`, whichever comes first.
     */
   def unsafeDispatch(request: HttpRequest): Future[ReleaseableResponse]
@@ -56,6 +56,11 @@ object HttpClient {
     */
   lazy val basicHttp1Client: HttpClient = {
     val pool = new BasicHttp1ClientSessionManager(HttpClientConfig.Default)
+    new HttpClientImpl(pool)
+  }
+
+  lazy val pooledHttpClient: HttpClient = {
+    val pool = ClientSessionManagerImpl(HttpClientConfig.Default)
     new HttpClientImpl(pool)
   }
 }

--- a/http/src/main/scala/org/http4s/blaze/http/InternalWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/InternalWriter.scala
@@ -3,7 +3,6 @@ package org.http4s.blaze.http
 import java.io.IOException
 import scala.concurrent.Future
 
-
 private object InternalWriter {
   val cachedSuccess = Future.successful(())
   def closedChannelException = Future.failed(new IOException("Channel closed"))

--- a/http/src/test/scala/org/http4s/blaze/http/ClientSessionManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/ClientSessionManagerImplSpec.scala
@@ -1,0 +1,87 @@
+package org.http4s.blaze.http
+
+import org.http4s.blaze.http.HttpClientSession.{Closed, Ready, ReleaseableResponse, Status}
+import org.specs2.mutable.Specification
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Success
+
+class ClientSessionManagerImplSpec extends Specification {
+
+  private val connectionId = ClientSessionManagerImpl.ConnectionId("http", "www.foo.com")
+
+  private val req = HttpRequest("GET", "http://www.foo.com/bar", 1, 1, Seq.empty, BodyReader.EmptyBodyReader)
+
+  private def cacheWithSessions(sessions: HttpClientSession*): java.util.Map[ClientSessionManagerImpl.ConnectionId, java.util.Collection[HttpClientSession]] = {
+    val map = new java.util.HashMap[ClientSessionManagerImpl.ConnectionId, java.util.Collection[HttpClientSession]]()
+    val coll = new java.util.LinkedList[HttpClientSession]()
+    sessions.foreach(coll.add(_))
+    map.put(connectionId, coll)
+    map
+  }
+
+  private def managerWithSessions(sessions: HttpClientSession*): ClientSessionManagerImpl = {
+    val cache = cacheWithSessions(sessions:_*)
+    new ClientSessionManagerImpl(cache, HttpClientConfig.Default)
+  }
+
+  "ClientSessionManagerImpl" should {
+    "acquire an existing session from the pool" in {
+      val session = new Http1ClientSession {
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = ???
+        override def status: Status = Ready
+      }
+
+      val manager = managerWithSessions(session)
+      manager.acquireSession(req).value must beSome(Success(session))
+    }
+
+    "add a good session back to the pool" in {
+      val session = new Http1ClientSession {
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = ???
+        override def status: Status = Ready
+      }
+      val cache = new java.util.HashMap[ClientSessionManagerImpl.ConnectionId, java.util.Collection[HttpClientSession]]()
+      val manager = new ClientSessionManagerImpl(cache, HttpClientConfig.Default)
+
+      val proxiedSession = ClientSessionManagerImpl.Http1SessionProxy(connectionId, session)
+
+      manager.returnSession(proxiedSession)
+      cache.get(connectionId).iterator.next must_== proxiedSession
+    }
+
+    "dead HTTP/2 sesssions are removed" in {
+      object bad extends Http2ClientSession {
+        var closed = false
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = {
+          closed = true
+          Future.successful(())
+        }
+        override def status: Status = Closed
+        override def quality: Double = 1.0
+      }
+
+      object lowQuality extends Http2ClientSession {
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = ???
+        override def status: Status = Ready
+        override def quality: Double = 0.0
+      }
+
+      object good extends Http2ClientSession {
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = ???
+        override def status: Status = Ready
+        override def quality: Double = 1.0
+      }
+
+      val manager = managerWithSessions(bad, lowQuality, good)
+      manager.acquireSession(req).value must beSome(Success(good))
+      bad.closed must beTrue
+    }
+  }
+}


### PR DESCRIPTION
A rough example of a pooling session manager. I don't think this should be considered 'production ready' since it doesn't put limits on the number of cached sessions and doesn't do a great job cleaning up bad sessions, but it should be a reasonable starting point and provides a mechanism for demonstrating the HTTP/2 client.