### PR TITLE
Add HTTP/2 flow control tools

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http2/FlowStrategy.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/FlowStrategy.scala
@@ -1,0 +1,43 @@
+package org.http4s.blaze.http.http2
+
+import org.http4s.blaze.http.http2.FlowStrategy.Increment
+
+/** The goal of the `FlowStrategy` is to advise when to do windows updates for inbound data */
+trait FlowStrategy {
+  /** Decide if the session window needs to send a WINDOW_UPDATE frame
+    *
+    * @note This must not mutate the [[SessionFlowControl]] in any way.
+    * @note This verison should only be used in situations where the stream associated
+    *       with the data does not exist. For example, it may have already closed and
+    *       sent a RST frame.
+    *
+    * @param session the session [[SessionFlowControl]]
+    * @return number of bytes to update the session flow window with.
+    */
+  def checkSession(session: SessionFlowControl): Int
+
+  /** Decide if the stream and/or the session need a WINDOW_UPDATE frame
+    *
+    * @note This must not mutate the [[SessionFlowControl]] or the [[StreamFlowWindow]] in any way.
+    *
+    * @param session the session [[SessionFlowControl]]
+    * @param stream the stream [[StreamFlowWindow]]
+    * @return the number of bytes to update the session and stream flow window with.
+    */
+  def checkStream(session: SessionFlowControl, stream: StreamFlowWindow): Increment
+}
+
+object FlowStrategy {
+  final class Increment private[FlowStrategy](val session: Int, val stream: Int) {
+    override def toString: String = s"Increment($session, $stream)"
+  }
+
+  val Empty = new Increment(0, 0) // Cached version for avoiding allocations
+
+  object Increment {
+    def apply(session: Int, stream: Int): Increment = {
+      if (session == 0 && stream == 0) Empty
+      else new Increment(session, stream)
+    }
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SessionFlowControl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SessionFlowControl.scala
@@ -1,0 +1,42 @@
+package org.http4s.blaze.http.http2
+
+/** Flow control representation of a Http2 Session */
+abstract class SessionFlowControl {
+
+  /** Create a new [[StreamFlowWindow]] for a stream which will update and check the
+    * bounds of the session flow control state.
+    *
+    * @note the stream [[StreamFlowWindow]] is not thread safe.
+    */
+  def newStreamFlowWindow(streamId: Int): StreamFlowWindow
+
+  /** Get the number of bytes remaining in the inbound flow window */
+  def sessionInboundWindow: Int
+
+  /** Observe inbound bytes that don't belong to an active inbound stream
+    *
+    * @param count bytes observed
+    * @return `true` if there was sufficient session flow window remaining, `false` otherwise.
+    */
+  def sessionInboundObserved(count: Int): Boolean
+
+  /** Update the session inbound window */
+  def sessionInboundAcked(count: Int): Unit
+
+  /** Signal that inbound bytes have been consumed that are not tracked by a stream */
+  def sessionInboundConsumed(count: Int): Unit
+
+  /** Get the total number of inbound bytes that have yet to be consumed by the streams */
+  def sessionUnconsumedBytes: Int
+
+  /** Get the remaining bytes in the sessions outbound flow window */
+  def sessionOutboundWindow: Int
+
+  /** Update the session outbound window
+    *
+    * @note there is no way to withdraw outbound bytes directly from
+    *       the session as there should always be an associated stream
+    *       when sending flow control counted bytes outbound.
+    */
+  def sessionOutboundAcked(count: Int): MaybeError
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SessionFlowControlImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SessionFlowControlImpl.scala
@@ -1,0 +1,196 @@
+package org.http4s.blaze.http.http2
+
+import org.http4s.blaze.http.http2.Http2Settings.DefaultSettings
+import org.http4s.blaze.http.http2.Http2Exception.{FLOW_CONTROL_ERROR, PROTOCOL_ERROR}
+
+
+/** Flow control representation of a Http2 Session
+  *
+  * @param localSettings HTTP2 settings to be used for creating new stream inbound windows
+  * @param peerSettings HTTP2 settings to be used for creating new stream outbound windows
+  */
+private abstract class SessionFlowControlImpl(
+  localSettings: Http2Settings,
+  peerSettings: Http2Settings
+) extends SessionFlowControl {
+
+  private[this] var _sessionInboundWindow: Int = DefaultSettings.INITIAL_WINDOW_SIZE
+  private[this] var _sessionOutboundWindow: Int = DefaultSettings.INITIAL_WINDOW_SIZE
+  private[this] var _sessionUnconsumedInbound: Int = 0
+
+  /** Called when bytes have been consumed that are not associated with a live stream id.
+    *
+    * @param consumed the number of bytes consumed.
+    */
+  protected def onSessonBytesConsumed(consumed: Int): Unit
+
+  /** Called when bytes have been consumed from a live stream
+    *
+    * @param stream stream associated with the consumed bytes
+    * @param consumed
+    */
+  protected def onStreamBytesConsumed(stream: StreamFlowWindow, consumed: Int): Unit
+
+  // Concrete methods /////////////////////////////////////////////////////////////
+
+  /** Create a new [[StreamFlowWindow]] for a stream which will update and check the
+    * bounds of the session flow control state.
+    *
+    * @note the stream [[StreamFlowWindow]] is not thread safe.
+    */
+  final override def newStreamFlowWindow(streamId: Int): StreamFlowWindow = {
+    require(streamId > 0)
+    new StreamFlowWindowImpl(streamId)
+  }
+
+  /** Get the number of bytes remaining in the inbound flow window */
+  final override def sessionInboundWindow: Int = _sessionInboundWindow
+
+  /** Observe inbound bytes that don't belong to an active inbound stream
+    *
+    * @param count bytes observed
+    * @return `true` if there was sufficient session flow window remaining, `false` otherwise.
+    */
+  final override def sessionInboundObserved(count: Int): Boolean = {
+    require(count >= 0)
+
+    if (sessionInboundWindow < count) false
+    else {
+      _sessionInboundWindow -= count
+      _sessionUnconsumedInbound += count
+      true
+    }
+  }
+
+  /** Update the session inbound window */
+  final override def sessionInboundAcked(count: Int): Unit = {
+    require(count >= 0)
+    _sessionInboundWindow += count
+  }
+
+  /** Signal that inbound bytes have been consumed that are not tracked by a stream */
+  final override def sessionInboundConsumed(count: Int): Unit = {
+    require(count >= 0)
+    if (count > _sessionUnconsumedInbound) {
+      val msg = s"Consumed more bytes ($count) than had been accounted for (${_sessionUnconsumedInbound})"
+      throw new IllegalStateException(msg)
+    } else if (count > 0) {
+      _sessionUnconsumedInbound -= count
+      onSessonBytesConsumed(count)
+    }
+  }
+
+  /** Get the total number of inbound bytes that have yet to be consumed by the streams */
+  final override def sessionUnconsumedBytes: Int = _sessionUnconsumedInbound
+
+  /** Get the remaining bytes in the sessions outbound flow window */
+  final override def sessionOutboundWindow: Int =  _sessionOutboundWindow
+
+  /** Update the session outbound window
+    *
+    * @note there is no way to withdraw outbound bytes directly from
+    *       the session as there should always be an associated stream
+    *       when sending flow control counted bytes outbound.
+    */
+  final override def sessionOutboundAcked(count: Int): MaybeError = {
+    // Updates MUST be greater than 0, otherwise its protocol error
+    // https://tools.ietf.org/html/rfc7540#section-6.9
+    if (count <= 0) {
+      Error(PROTOCOL_ERROR.goaway("Invalid session WINDOW_UPDATE: size <= 0."))
+    } else if (Int.MaxValue - sessionOutboundWindow < count) {
+      // A sender MUST NOT allow a flow-control window to exceed 2^31-1 octets.
+      // https://tools.ietf.org/html/rfc7540#section-6.9.1
+      Error(FLOW_CONTROL_ERROR.goaway("Session flow control exceeded max window."))
+    } else {
+      _sessionOutboundWindow += count
+      Continue
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////
+
+  private[this] final class StreamFlowWindowImpl(val streamId: Int)
+    extends StreamFlowWindow {
+
+    private[this] var _streamInboundWindow: Int = localSettings.initialWindowSize
+    private[this] var _streamOutboundWindow: Int = peerSettings.initialWindowSize
+    private[this] var _streamUnconsumedInbound: Int = 0
+
+    override def sessionFlowControl: SessionFlowControl = SessionFlowControlImpl.this
+
+    override def streamUnconsumedBytes: Int = _streamUnconsumedInbound
+
+    override def streamOutboundWindow: Int = _streamOutboundWindow
+
+    override def peerSettingsInitialWindowChange(delta: Int): MaybeError =
+      adjustOutbound(delta)
+
+    override def streamOutboundAcked(count: Int): MaybeError = {
+      // Updates MUST be greater than 0, otherwise its protocol error
+      // https://tools.ietf.org/html/rfc7540#section-6.9
+      if (count <= 0) {
+        Error(PROTOCOL_ERROR.goaway(
+          s"Invalid stream ($streamId) WINDOW_UPDATE: size <= 0."))
+      } else if (Int.MaxValue - sessionOutboundWindow < count) {
+        // A sender MUST NOT allow a flow-control window to exceed 2^31-1 octets.
+        // https://tools.ietf.org/html/rfc7540#section-6.9.1
+        Error(FLOW_CONTROL_ERROR.rst(streamId, "Session flow control exceeded max window."))
+      } else {
+        adjustOutbound(count)
+      }
+    }
+
+    private[this] def adjustOutbound(delta: Int): MaybeError = {
+      // A sender MUST NOT allow a flow-control window to exceed 2^31-1 octets.
+      // https://tools.ietf.org/html/rfc7540#section-6.9.1
+      if (Int.MaxValue - sessionOutboundWindow < delta) {
+        Error(FLOW_CONTROL_ERROR.goaway(s"Flow control exceeded max window for stream $streamId."))
+      } else {
+        _streamOutboundWindow += delta
+        Continue
+      }
+    }
+
+    override def outboundRequest(request: Int): Int = {
+      require(request >= 0)
+
+      val withdrawal = math.min(sessionOutboundWindow, math.min(request, streamOutboundWindow))
+      _sessionOutboundWindow -= withdrawal
+      _streamOutboundWindow -= withdrawal
+      withdrawal
+    }
+
+    override def streamInboundWindow: Int =  _streamInboundWindow
+
+    override def inboundObserved(count: Int): Boolean = {
+      require(count >= 0)
+      if (count > streamInboundWindow || count > sessionInboundWindow) false
+      else {
+        _streamUnconsumedInbound += count
+        _sessionUnconsumedInbound += count
+
+        _streamInboundWindow -= count
+        _sessionInboundWindow -= count
+
+        true
+      }
+    }
+
+    override def inboundConsumed(count: Int): Unit = {
+      require(count >= 0 && count <= streamUnconsumedBytes && count <= sessionUnconsumedBytes)
+
+      if (count > 0) {
+        _streamUnconsumedInbound -= count
+        _sessionUnconsumedInbound -= count
+
+        onSessonBytesConsumed(count)
+        onStreamBytesConsumed(this, count)
+      }
+    }
+
+    override def streamInboundAcked(count: Int): Unit = {
+      require(count >= 0)
+      _streamInboundWindow += count
+    }
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamFlowWindow.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamFlowWindow.scala
@@ -1,0 +1,72 @@
+package org.http4s.blaze.http.http2
+
+/** Representation of the flow control state of a stream belonging to a session
+  *
+  * The `StreamFlowWindow` provides the tools for tracking the flow window for
+  * both the individual stream and the session that it belongs to.
+  */
+abstract class StreamFlowWindow {
+
+  /** The flow control manager of the session this stream belongs to */
+  def sessionFlowControl: SessionFlowControl
+
+  /** Id of the associated stream */
+  def streamId: Int
+
+  /** Get the number of stream inbound bytes that haven't been consumed */
+  def streamUnconsumedBytes: Int
+
+  /** Get the remaining bytes in the stream outbound window */
+  def streamOutboundWindow: Int
+
+  /** Get the remaining outbound window, considering both the session and stream windows */
+  final def outboundWindow: Int =
+    math.min(streamOutboundWindow, sessionFlowControl.sessionOutboundWindow)
+
+  /** Determine whether we have available flow window remaining, considering
+    * both the stream and the session flow windows
+    */
+  final def outboundWindowAvailable: Boolean =
+    streamOutboundWindow > 0 && sessionFlowControl.sessionOutboundWindow > 0
+
+  /** Adjust the stream flow window to account for a change in INITIAL_WINDOW_SIZE
+    *
+    * If an error is returned, the internal state _must not_ be modified.
+    *
+    * @param delta change in intial window size. Maybe be positive or negative, but must not
+    *              cause the window to overflow Int.MaxValue.
+    */
+  def peerSettingsInitialWindowChange(delta: Int): MaybeError
+
+  /** Signal that a stream window update was received for `count` bytes */
+  def streamOutboundAcked(count: Int): MaybeError
+
+  /** Request to withdraw bytes from the outbound window of the stream
+    * and the session.
+    *
+    * @param request maximum bytes to withdraw
+    * @return actual bytes withdrawn from the window
+    */
+  def outboundRequest(request: Int): Int
+
+  /** Get the remaining bytes in the streams inbound window */
+  def streamInboundWindow: Int
+
+  /** Attempts to withdraw `count` bytes from the inbound window of both the stream and the session.
+    *
+    * If there are sufficient bytes in the stream and session flow windows, they are subtracted,
+    * otherwise the window is unmodified.
+    *
+    * @return `true` if withdraw was successful, `false` otherwise.
+    */
+  def inboundObserved(count: Int): Boolean
+
+  /** Signal that `count` bytes have been consumed by the stream
+    *
+    * @note The consumed bytes are also counted for the session flow window.
+    */
+  def inboundConsumed(count: Int): Unit
+
+  /** Signal that a stream window update was sent for `count` bytes */
+  def streamInboundAcked(count: Int): Unit
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/Mocks.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/Mocks.scala
@@ -1,0 +1,39 @@
+package org.http4s.blaze.http.http2
+
+import org.http4s.blaze.util.Execution
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+
+private class MockFlowControl(
+  mySettings: Http2Settings,
+  peerSettings: Http2Settings
+) extends SessionFlowControlImpl(mySettings, peerSettings) {
+  sealed trait Operation
+  case class SessionConsumed(bytes: Int) extends Operation
+  case class StreamConsumed(stream: StreamFlowWindow, consumed: Int) extends Operation
+
+  val observedOps = new ListBuffer[Operation]
+
+  override protected def onSessonBytesConsumed(consumed: Int): Unit = {
+    observedOps += SessionConsumed(consumed)
+    ()
+  }
+
+  override protected def onStreamBytesConsumed(stream: StreamFlowWindow, consumed: Int): Unit = {
+    observedOps += StreamConsumed(stream, consumed)
+    ()
+  }
+}
+
+
+private class Http2MockTools(isClient: Boolean) {
+
+  lazy val mySettings: MutableHttp2Settings = MutableHttp2Settings.default()
+
+  lazy val peerSettings: MutableHttp2Settings = MutableHttp2Settings.default()
+
+  lazy val flowControl: MockFlowControl = new MockFlowControl(mySettings, peerSettings)
+
+  lazy val sessionExecutor: ExecutionContext = Execution.trampoline
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/SessionFlowControlSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/SessionFlowControlSpec.scala
@@ -1,0 +1,307 @@
+package org.http4s.blaze.http.http2
+
+import org.http4s.blaze.http.http2.Http2Settings.DefaultSettings
+import org.specs2.mutable.Specification
+
+class SessionFlowControlSpec extends Specification {
+
+  private class TestSessionFlowControl(inbound: Http2Settings, outbound: Http2Settings)
+    extends SessionFlowControlImpl(inbound, outbound) {
+    var sessionConsumed: Int = 0
+
+    var streamThatConsumed: StreamFlowWindow = null
+    var streamConsumed: Int = 0
+
+    override protected def onSessonBytesConsumed(consumed: Int): Unit = {
+      this.sessionConsumed = consumed
+    }
+
+    override protected def onStreamBytesConsumed(stream: StreamFlowWindow, consumed: Int): Unit = {
+      streamThatConsumed = stream
+      streamConsumed = consumed
+    }
+  }
+
+  private def flowControl(): TestSessionFlowControl = {
+    val settings = Http2Settings.default
+    flowControl(settings, settings)
+  }
+
+  private def flowControl(inbound: Http2Settings, outbound: Http2Settings): TestSessionFlowControl = {
+    new TestSessionFlowControl(inbound, outbound)
+  }
+
+  "SessionFlowControl session inbound window" should {
+    "Start with the http2 default flow windows" in {
+      val flow = flowControl()
+      flow.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+      flow.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "bytes consumed" in {
+      val flow = flowControl()
+      flow.sessionUnconsumedBytes must_== 0
+      flow.sessionInboundObserved(10) must beTrue
+      flow.sessionUnconsumedBytes must_== 10
+
+      flow.sessionConsumed must_== 0
+      flow.sessionInboundConsumed(1)
+
+      flow.sessionConsumed must_== 1
+      flow.sessionUnconsumedBytes must_== 9
+    }
+  }
+
+  "SessionFlowControl session inbound window" should {
+    "Zero session inbound withdrawals don't deplete the window" in {
+      val flow = flowControl()
+      flow.sessionInboundObserved(0) must beTrue
+      flow.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "session inbound withdrawals less than the window are successful" in {
+      val flow = flowControl()
+      flow.sessionInboundObserved(1) must beTrue
+      flow.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 1
+    }
+
+    "session inbound withdrawals greater than the window result in false and don't deplete the window" in {
+      val flow = flowControl()
+      flow.sessionInboundObserved(DefaultSettings.INITIAL_WINDOW_SIZE + 1) must beFalse
+      flow.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "session inbound withdrawals equal than the window are successful" in {
+      val flow = flowControl()
+      flow.sessionInboundObserved(DefaultSettings.INITIAL_WINDOW_SIZE) must beTrue
+      flow.sessionInboundWindow must_== 0
+    }
+
+    "session inbound deposits update the window" in {
+      val flow = flowControl()
+      flow.sessionInboundAcked(1)
+      flow.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE + 1
+    }
+
+    "session inbound deposits update the window to Int.MaxValue" in {
+      val flow = flowControl()
+      flow.sessionInboundAcked(Int.MaxValue - flow.sessionInboundWindow)
+      flow.sessionInboundWindow must_== Int.MaxValue
+    }
+  }
+
+  "SessionFlowControl session outbound window" should {
+    "session outbound deposits update the window" in {
+      val flow = flowControl()
+      flow.sessionOutboundAcked(1) must_== Continue
+      flow.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE + 1
+    }
+
+    "session outbound deposits update the window to Int.MaxValue" in {
+      val flow = flowControl()
+      flow.sessionOutboundAcked(Int.MaxValue - flow.sessionOutboundWindow) must_== Continue
+      flow.sessionOutboundWindow must_== Int.MaxValue
+    }
+
+    // https://tools.ietf.org/html/rfc7540#section-6.9
+    "session outbound deposits of 0 throw Http2Exception with flag FLOW_CONTROL" in {
+      val flow = flowControl()
+      flow.sessionOutboundAcked(0) must be like {
+        case Error(Http2SessionException(code, name)) => code must_== Http2Exception.PROTOCOL_ERROR.code
+      }
+    }
+
+    // https://tools.ietf.org/html/rfc7540#section-6.9.1
+    "session outbound deposits that overflow the window throw Http2Exception with flag FLOW_CONTROL" in {
+      val flow = flowControl()
+      val overflowBy1 = Int.MaxValue - flow.sessionOutboundWindow + 1
+      flow.sessionOutboundAcked(overflowBy1) must be like {
+        case Error(Http2SessionException(code, name)) => code must_== Http2Exception.FLOW_CONTROL_ERROR.code
+      }
+    }
+  }
+
+  ////////////////// Streams ////////////////////////////
+  "SessionFlowControl.StreamFlowWindow inbound window" should {
+    "Start with the config initial flow windows" in {
+      val inbound = Http2Settings.default.copy(initialWindowSize = 2)
+      val outbound = Http2Settings.default.copy(initialWindowSize = 1)
+      val flow = flowControl(inbound, outbound).newStreamFlowWindow(1)
+
+      flow.streamInboundWindow must_== 2
+      flow.streamOutboundWindow must_== 1
+    }
+
+    "bytes consumed" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      session.sessionUnconsumedBytes must_== 0
+      flow.streamUnconsumedBytes must_== 0
+
+      flow.inboundObserved(10) must beTrue
+
+      session.sessionUnconsumedBytes must_== 10
+      flow.streamUnconsumedBytes must_== 10
+
+      session.sessionConsumed must_== 0
+      session.streamConsumed must_== 0
+      flow.inboundConsumed(1)
+
+      (session.streamThatConsumed eq flow) must beTrue
+      session.sessionConsumed must_== 1
+      session.streamConsumed must_== 1
+
+      session.sessionUnconsumedBytes must_== 9
+      flow.streamUnconsumedBytes must_== 9
+    }
+  }
+
+  "SessionFlowControl.StreamFlowWindow inbound window" should {
+    "zero inbound withdrawals don't deplete the window" in {
+      val flow = flowControl().newStreamFlowWindow(1)
+      flow.inboundObserved(0) must beTrue
+      flow.streamInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "inbound withdrawals less than the window are successful" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+      flow.inboundObserved(1) must beTrue
+
+      flow.streamInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 1
+      session.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 1
+    }
+
+    "inbound withdrawals greater than the window result in false and don't deplete the window" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+      flow.inboundObserved(DefaultSettings.INITIAL_WINDOW_SIZE + 1) must beFalse
+
+      flow.streamInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+      session.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "inbound withdrawals equal than the window are successful" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.inboundObserved(DefaultSettings.INITIAL_WINDOW_SIZE) must beTrue
+      flow.streamInboundWindow must_== 0
+      session.sessionInboundWindow must_== 0
+    }
+
+    "inbound deposits update the window" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.streamInboundAcked(1)
+      flow.streamInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE + 1
+      session.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "inbound deposits update the window to Int.MaxValue" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.streamInboundAcked(Int.MaxValue - flow.streamInboundWindow)
+      session.sessionInboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+  }
+
+  "SessionFlowControlStreamFlowWindow outbound window" should {
+    "deposits update the window" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.streamOutboundAcked(1) must_== Continue
+
+      flow.streamOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE + 1
+      session.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "outbound deposits update the window to Int.MaxValue" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.streamOutboundAcked(Int.MaxValue - flow.streamOutboundWindow) must_== Continue
+
+      flow.streamOutboundWindow must_== Int.MaxValue
+      session.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    // https://tools.ietf.org/html/rfc7540#section-6.9
+    "outbound deposits of 0 throw Http2Exception with flag FLOW_CONTROL" in {
+      val flow = flowControl().newStreamFlowWindow(1)
+
+      flow.streamOutboundAcked(0) must be like {
+        case Error(Http2SessionException(code, name)) => code must_== Http2Exception.PROTOCOL_ERROR.code
+      }
+    }
+
+    // https://tools.ietf.org/html/rfc7540#section-6.9.1
+    "outbound deposits that overflow the window throw Http2Exception with flag FLOW_CONTROL" in {
+      val flow = flowControl().newStreamFlowWindow(1)
+
+      val overflowBy1 = Int.MaxValue - flow.streamOutboundWindow + 1
+      flow.streamOutboundAcked(overflowBy1) must be like {
+        case Error(Http2StreamException(streamId, code, _)) =>
+          streamId must_== flow.streamId
+          code must_== Http2Exception.FLOW_CONTROL_ERROR.code
+      }
+    }
+
+    "outbound withdrawal of 0 don't effect the windows" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.outboundRequest(0) must_== 0
+      flow.streamOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+      session.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+    }
+
+    "outbound withdrawals are accounted for" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.outboundRequest(DefaultSettings.INITIAL_WINDOW_SIZE) must_== DefaultSettings.INITIAL_WINDOW_SIZE
+      flow.streamOutboundWindow must_== 0
+      session.sessionOutboundWindow must_== 0
+    }
+
+    "outbound withdrawals that exceed the window" in {
+      val session = flowControl()
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.outboundRequest(DefaultSettings.INITIAL_WINDOW_SIZE + 1) must_== DefaultSettings.INITIAL_WINDOW_SIZE
+      flow.streamOutboundWindow must_== 0
+      session.sessionOutboundWindow must_== 0
+    }
+
+    "outbound withdrawals that exceed the window consume the max from stream or session" in {
+      val config = Http2Settings.default.copy(initialWindowSize = 1)
+      val session = flowControl(config, config)
+      val flow = session.newStreamFlowWindow(1)
+
+      flow.outboundRequest(10) must_== 1
+      flow.streamOutboundWindow must_== 0
+      session.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 1
+    }
+
+    "outbound withdrawals from multiple streams" in {
+      val session = flowControl()
+      val flow1 = session.newStreamFlowWindow(1)
+      val flow2 = session.newStreamFlowWindow(2)
+
+      flow1.outboundRequest(10) must_== 10
+      flow1.streamOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 10
+      flow2.streamOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE
+      session.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 10
+
+      flow2.outboundRequest(20) must_== 20
+      flow2.streamOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 20
+      flow1.streamOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 10
+      session.sessionOutboundWindow must_== DefaultSettings.INITIAL_WINDOW_SIZE - 30
+    }
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/StreamFlowWindowSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/StreamFlowWindowSpec.scala
@@ -1,0 +1,45 @@
+package org.http4s.blaze.http.http2
+
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class StreamFlowWindowSpec extends Specification with Mockito {
+  "StreamFlowWindow" >> {
+    "outboundWindow gives minimum of session and stream outbound windows" >> {
+      val tools = new Http2MockTools(true /*isClient*/)
+      val initialSessionWindow = tools.flowControl.sessionOutboundWindow
+
+      initialSessionWindow must beGreaterThan(10) // sanity check
+      val window = mock[StreamFlowWindow]
+      window.streamOutboundWindow returns 10
+      window.sessionFlowControl returns tools.flowControl
+      window.outboundWindow must_== 10
+
+      // deplete the session window and make sure we get a 0 out
+      tools.flowControl.newStreamFlowWindow(1).outboundRequest(initialSessionWindow) must_== initialSessionWindow
+      window.outboundWindow must_== 0
+    }
+
+    "outboundWindowAvailable" >> {
+      val tools = new Http2MockTools(true /*isClient*/)
+      val initialSessionWindow = tools.flowControl.sessionOutboundWindow
+
+      tools.flowControl.sessionOutboundWindow must beGreaterThan(10) // sanity check
+      val window = mock[StreamFlowWindow]
+      window.streamOutboundWindow returns 10
+      window.sessionFlowControl returns tools.flowControl
+      window.outboundWindowAvailable must beTrue // neither depleted
+
+      window.streamOutboundWindow returns 0
+      window.outboundWindowAvailable must beFalse // stream depleted
+
+      // deplete the session window and make sure we get a false
+      tools.flowControl.newStreamFlowWindow(1).outboundRequest(initialSessionWindow) must_== initialSessionWindow
+      window.outboundWindowAvailable must beFalse // both depleted
+
+      window.streamOutboundWindow returns 10
+      window.outboundWindowAvailable must beFalse // session depleted
+    }
+  }
+
+}


### PR DESCRIPTION
Add configurable flow control for HTTP/2. The FlowStrategy
is responsible for determining when to ACK inbound data.