### PR TITLE
Add Header encoder and decoders

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http2/ByteBufferInputStream.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/ByteBufferInputStream.scala
@@ -1,0 +1,51 @@
+package org.http4s.blaze.http.http2
+
+import java.io.{IOException, InputStream}
+import java.nio.ByteBuffer
+
+/** Wrap a `ByteBuffer` in an `InputStream` interface.
+  * This is just an adapter to work with the twitter hpack
+  * implementation. I would really like to get rid of it.
+  */
+private final class ByteBufferInputStream(buffer: ByteBuffer) extends InputStream {
+
+  private[this] var markSize = -1
+
+  override def read(): Int = {
+    if (buffer.hasRemaining) {
+      markSize -= 1
+      buffer.get() & 0xff
+    }
+    else -1
+  }
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = {
+    if (!buffer.hasRemaining) -1
+    else {
+      val readSize = math.min(len, buffer.remaining)
+      markSize -= readSize
+      // the buffer.get call will check the array bounds
+      buffer.get(b, off, readSize)
+      readSize
+    }
+  }
+
+  override def available(): Int = buffer.remaining
+
+  override def mark(readlimit: Int): Unit = {
+    markSize = readlimit
+    buffer.mark()
+    ()
+  }
+
+  override def reset(): Unit = {
+    if (markSize >= 0) {
+      markSize = -1
+      buffer.reset()
+      ()
+    }
+    else throw new IOException("Invalid mark")
+  }
+
+  override def markSupported(): Boolean = true
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/HeaderDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/HeaderDecoder.scala
@@ -1,0 +1,91 @@
+package org.http4s.blaze.http.http2
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.US_ASCII
+
+import org.http4s.blaze.http.http2.Http2Exception._
+import org.http4s.blaze.http.http2.Http2Settings.DefaultSettings
+import org.http4s.blaze.util.BufferTools
+import com.twitter.hpack.{Decoder, HeaderListener}
+
+import scala.collection.immutable.VectorBuilder
+
+/** Decoder of HEADERS frame payloads into a collection of key-value
+  * pairs using a HPACK decoder.
+  *
+  * @param maxHeaderListSize maximum allowed size of the header block.
+  *
+  * "The value is based on the uncompressed size of header fields,
+  *  including the length of the name and value in octets plus an
+  *  overhead of 32 octets for each header field."
+  * https://tools.ietf.org/html/rfc7540#section-6.5.2
+  * @param maxTableSize maximum compression table to maintain
+  */
+final class HeaderDecoder(
+  maxHeaderListSize: Int,
+  discardOverflowHeaders: Boolean,
+  val maxTableSize: Int
+) {
+  require(maxTableSize >= DefaultSettings.HEADER_TABLE_SIZE)
+
+  private[this] val acc = new VectorBuilder[(String, String)]
+  private[this] var leftovers: ByteBuffer = null
+  private[this] var headerBlockSize = 0
+
+  private[this] val decoder = new Decoder(maxHeaderListSize, maxTableSize)
+  private[this] val listener = new HeaderListener {
+    override def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit = {
+      headerBlockSize += 32 + name.length + value.length
+      if (!discardOverflowHeaders || !headerListSizeOverflow) {
+        acc += new String(name, US_ASCII) -> new String(value, US_ASCII)
+        ()
+      }
+    }
+  }
+
+  /** Set the HEADER_TABLE_SIZE parameter */
+  def setMaxHeaderTableSize(max: Int): Unit = decoder.setMaxHeaderTableSize(max)
+
+  /** Returns the header collection and clears the builder */
+  def result(): Seq[(String,String)] = {
+    val result = acc.result()
+    acc.clear()
+    headerBlockSize = 0
+    result
+  }
+
+  def currentHeaderBlockSize: Int = headerBlockSize
+
+  def headerListSizeOverflow: Boolean = currentHeaderBlockSize > maxHeaderListSize
+
+  /** Decode the headers into the internal header accumulator */
+  def decode(buffer: ByteBuffer, streamId: Int, endHeaders: Boolean): MaybeError =
+    doDecode(buffer, streamId, endHeaders, listener)
+
+  private[this] def doDecode(
+    buffer: ByteBuffer,
+    streamId: Int,
+    endHeaders: Boolean,
+    listener: HeaderListener): MaybeError = {
+    try {
+      val buff = BufferTools.concatBuffers(leftovers, buffer)
+      decoder.decode(new ByteBufferInputStream(buff), listener)
+
+      if (!buff.hasRemaining()) leftovers = null
+      else if (buff ne buffer) leftovers = buff // we made a copy with concatBuffers
+      else {  // buff == input buffer. Need to copy the input buffer so we are not sharing it
+        val b = BufferTools.allocate(buff.remaining())
+        b.put(buff).flip()
+        leftovers = b
+      }
+
+      if (endHeaders) {
+        decoder.endHeaderBlock()
+      }
+
+      Continue
+    } catch { case t: Throwable =>
+      Error(COMPRESSION_ERROR.goaway(s"Compression error on stream $streamId"))
+    }
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/HeaderEncoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/HeaderEncoder.scala
@@ -1,0 +1,41 @@
+package org.http4s.blaze.http.http2
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.US_ASCII
+
+import com.twitter.hpack.Encoder
+
+/** HTTP/2 HPACK header encoder
+  *
+  * @param initialMaxTableSize maximum HPACK table size the peer
+  *                            will allow.
+  */
+class HeaderEncoder(initialMaxTableSize: Int) {
+  private[this] var _maxTableSize = initialMaxTableSize
+  private[this] val encoder = new Encoder(maxTableSize)
+  private[this] val os = new ByteArrayOutputStream(1024)
+
+
+  /** The current value of SETTINGS_HEADER_TABLE_SIZE */
+  def maxTableSize: Int = _maxTableSize
+
+  /** This should only be changed by the peer */
+  def maxTableSize(max: Int): Unit = {
+    _maxTableSize = max
+    encoder.setMaxHeaderTableSize(os, max)
+  }
+
+  /** Encode the headers into the payload of a HEADERS frame */
+  def encodeHeaders(hs: Seq[(String, String)]): ByteBuffer = {
+    hs.foreach { case (k,v) =>
+      val keyBytes = k.getBytes(US_ASCII)
+      val valueBytes = v.getBytes(US_ASCII)
+      encoder.encodeHeader(os, keyBytes, valueBytes, false)
+    }
+
+    val buff = ByteBuffer.wrap(os.toByteArray())
+    os.reset()
+    buff
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/ByteBufferInputStreamSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/ByteBufferInputStreamSpec.scala
@@ -1,0 +1,54 @@
+package org.http4s.blaze.http.http2
+
+import java.nio.ByteBuffer
+
+import org.specs2.mutable.Specification
+
+class ByteBufferInputStreamSpec extends Specification {
+
+  private def fromByteBuffer(buffer: ByteBuffer): ByteBufferInputStream =
+    new ByteBufferInputStream(buffer)
+
+  private def fromBytes(bytes: Byte*): ByteBufferInputStream =
+    fromByteBuffer(ByteBuffer.wrap(bytes.toArray))
+
+  "ByteBufferInputStream" should {
+    "report available bytes" in {
+      forall(0 until 10) { i =>
+        val bb = ByteBuffer.wrap(new Array[Byte](i))
+        fromByteBuffer(bb).available() must_== i
+      }
+    }
+
+    "read -1 when bytes unavailable" in {
+      fromBytes().read() must_== -1
+    }
+
+    "read byte when available" in {
+      val range = 0 until 10
+      val is = fromBytes(range.map(_.toByte):_*)
+      forall(range) { i =>
+        is.read() must_== i
+      }
+
+      is.available() must_== 0
+      is.read() must_== -1
+    }
+
+    "handle mark and reset apporpriately" in {
+      val is = fromBytes((0 until 10).map(_.toByte):_*)
+
+      is.markSupported must beTrue
+
+      is.read() must_== 0
+      is.mark(1)
+      is.available() must_== 9
+      is.read() must_== 1
+      is.available() must_== 8
+      is.reset()
+      is.available() must_== 9
+      is.read() must_== 1
+      is.available() must_== 8
+    }
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/HeaderCodecHelpers.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/HeaderCodecHelpers.scala
@@ -11,6 +11,6 @@ object HeaderCodecHelpers {
   def decodeHeaders(bb: ByteBuffer, maxTableSize: Int): Seq[(String, String)] = {
     val dec = new HeaderDecoder(Int.MaxValue, false, maxTableSize)
     dec.decode(bb, -1, true)
-    dec.result()
+    dec.finish()
   }
 }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/HeaderCodecHelpers.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/HeaderCodecHelpers.scala
@@ -1,0 +1,16 @@
+package org.http4s.blaze.http.http2
+
+import java.nio.ByteBuffer
+
+object HeaderCodecHelpers {
+  def encodeHeaders(hs: Seq[(String, String)], maxTableSize: Int): ByteBuffer = {
+    val enc = new HeaderEncoder(maxTableSize)
+    enc.encodeHeaders(hs)
+  }
+
+  def decodeHeaders(bb: ByteBuffer, maxTableSize: Int): Seq[(String, String)] = {
+    val dec = new HeaderDecoder(Int.MaxValue, false, maxTableSize)
+    dec.decode(bb, -1, true)
+    dec.result()
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/HeaderDecoderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/HeaderDecoderSpec.scala
@@ -1,0 +1,78 @@
+package org.http4s.blaze.http.http2
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.util.BufferTools
+import org.specs2.mutable.Specification
+
+class HeaderDecoderSpec extends Specification {
+
+  private val testHeaders = Seq("foo" -> "bar")
+
+  private val headersBlockSize = testHeaders.foldLeft(0){ case (acc, (k,v)) =>
+    acc + 32 + k.length + v.length
+  }
+
+  "HeaderDecoder" should {
+    "decode a full headers block" in {
+      val bb = HeaderCodecHelpers.encodeHeaders(testHeaders, Int.MaxValue)
+      val dec = new HeaderDecoder(Int.MaxValue, false, Int.MaxValue)
+      dec.decode(bb, -1, true) must_== Continue
+      dec.result() must_== testHeaders
+
+      // Decode another block to make sure we don't contaminate the first
+      val nextHs = (0 until 10).map { i => i.toString -> i.toString }
+      val nextEncodedHs = HeaderCodecHelpers.encodeHeaders(nextHs, Int.MaxValue)
+
+      dec.decode(nextEncodedHs, -1, true) must_== Continue
+      dec.result() must_== nextHs
+    }
+
+    "decode a header block in chunks" in {
+      val bb = HeaderCodecHelpers.encodeHeaders(testHeaders, Int.MaxValue)
+      val dec = new HeaderDecoder(Int.MaxValue, false, Int.MaxValue)
+
+      val b1 = BufferTools.takeSlice(bb, bb.remaining() / 2)
+
+      dec.decode(b1, -1, false) must_== Continue
+      dec.decode(bb, -1, true) must_== Continue
+      dec.result() must_== testHeaders
+    }
+
+    "count the current header block size" in {
+      val bb = HeaderCodecHelpers.encodeHeaders(testHeaders, Int.MaxValue)
+      val dec = new HeaderDecoder(Int.MaxValue, false, Int.MaxValue)
+
+      dec.currentHeaderBlockSize must_== 0
+      dec.decode(bb, -1, true) must_== Continue
+      dec.currentHeaderBlockSize must_== headersBlockSize
+      dec.headerListSizeOverflow must beFalse
+
+      dec.result() must_== testHeaders
+      dec.currentHeaderBlockSize must_== 0
+    }
+
+    "now overflow the maxHeaderBlockSize" in {
+      val bb = HeaderCodecHelpers.encodeHeaders(testHeaders ++ testHeaders, Int.MaxValue)
+      val dec = new HeaderDecoder(headersBlockSize, /*discardOnOverflow*/ true, Int.MaxValue)
+
+      dec.decode(bb, -1, true) must_== Continue
+      dec.headerListSizeOverflow must beTrue
+      dec.result() must_== testHeaders // didn't get the second round
+      dec.headerListSizeOverflow must beFalse
+    }
+
+    "decompression errors are connection errors" in {
+      val bb = ByteBuffer.wrap(Array[Int](
+        0x00, 0x85, 0xf2, 0xb2, 0x4a, 0x84,
+        0xff, 0x84, 0x49, 0x50, 0x9f, 0xff).map(_.toByte)
+      )
+
+      val dec = new HeaderDecoder(Int.MaxValue, true, Int.MaxValue)
+      dec.decode(bb, -1, true) must throwA[Http2SessionException].like {
+        case Http2SessionException(code, _) =>
+          code must_== Http2Exception.COMPRESSION_ERROR.code
+      }
+    }.pendingUntilFixed("The twitter HPACK decoder isn't fully spec compliant yet")
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/HeaderDecoderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/HeaderDecoderSpec.scala
@@ -18,14 +18,14 @@ class HeaderDecoderSpec extends Specification {
       val bb = HeaderCodecHelpers.encodeHeaders(testHeaders, Int.MaxValue)
       val dec = new HeaderDecoder(Int.MaxValue, false, Int.MaxValue)
       dec.decode(bb, -1, true) must_== Continue
-      dec.result() must_== testHeaders
+      dec.finish() must_== testHeaders
 
       // Decode another block to make sure we don't contaminate the first
       val nextHs = (0 until 10).map { i => i.toString -> i.toString }
       val nextEncodedHs = HeaderCodecHelpers.encodeHeaders(nextHs, Int.MaxValue)
 
       dec.decode(nextEncodedHs, -1, true) must_== Continue
-      dec.result() must_== nextHs
+      dec.finish() must_== nextHs
     }
 
     "decode a header block in chunks" in {
@@ -36,7 +36,7 @@ class HeaderDecoderSpec extends Specification {
 
       dec.decode(b1, -1, false) must_== Continue
       dec.decode(bb, -1, true) must_== Continue
-      dec.result() must_== testHeaders
+      dec.finish() must_== testHeaders
     }
 
     "count the current header block size" in {
@@ -48,7 +48,7 @@ class HeaderDecoderSpec extends Specification {
       dec.currentHeaderBlockSize must_== headersBlockSize
       dec.headerListSizeOverflow must beFalse
 
-      dec.result() must_== testHeaders
+      dec.finish() must_== testHeaders
       dec.currentHeaderBlockSize must_== 0
     }
 
@@ -58,7 +58,7 @@ class HeaderDecoderSpec extends Specification {
 
       dec.decode(bb, -1, true) must_== Continue
       dec.headerListSizeOverflow must beTrue
-      dec.result() must_== testHeaders // didn't get the second round
+      dec.finish() must_== testHeaders // didn't get the second round
       dec.headerListSizeOverflow must beFalse
     }
 

--- a/http/src/test/scala/org/http4s/blaze/http/http2/HeaderEncoderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/HeaderEncoderSpec.scala
@@ -1,0 +1,15 @@
+package org.http4s.blaze.http.http2
+
+import org.specs2.mutable.Specification
+
+class HeaderEncoderSpec extends Specification {
+  private val headers = Seq("foo" -> "bar")
+  "HeaderEncoder" should {
+    "encode headers" in {
+      val enc = new HeaderEncoder(Int.MaxValue)
+      val bb = enc.encodeHeaders(headers)
+
+      HeaderCodecHelpers.decodeHeaders(bb, Int.MaxValue) must_== headers
+    }
+  }
+}


### PR DESCRIPTION
In HTTP/2 headers are transmitted using the HPACK compression scheme. We use the twitter HPACK implementation under the hood and wrap them in our own classes to provide a convenient interface and allow us to move to a new HPACK implementation in the future.