### PR TITLE
Call the threads blaze-*

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
@@ -70,7 +70,7 @@ class NIO1SocketServerGroup(pool: SelectorLoopPool) extends ServerChannelGroup {
   }
 
 
-  private class AcceptThread extends Thread("NIO1SocketServerGroup Acceptor") {
+  private class AcceptThread extends Thread("blaze-nio1-acceptor") {
     setDaemon(true)
 
     private val queue = new AtomicReference[List[NIO1ServerChannel]](Nil)

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoopPool.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoopPool.scala
@@ -20,7 +20,7 @@ trait SelectorLoopPool {
 class FixedSelectorPool(poolSize: Int, bufferSize: Int) extends SelectorLoopPool {
 
   private val loops = 0.until(poolSize).map { id =>
-    val l = new SelectorLoop(s"FixedPoolLoop-$id", Selector.open(), bufferSize)
+    val l = new SelectorLoop(s"blaze-nio-fixed-selector-pool-$id", Selector.open(), bufferSize)
     l.setDaemon(true)
     l.start()
     l

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/NIO2SocketServerGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/NIO2SocketServerGroup.scala
@@ -19,7 +19,7 @@ object NIO2SocketServerGroup {
     val factory = new ThreadFactory {
       val i = new AtomicInteger(0)
       override def newThread(r: Runnable): Thread = {
-        val t = new Thread(r, "NIO2SocketServerGroup-" + i.getAndIncrement())
+        val t = new Thread(r, "blaze-nio2-fixed-pool-" + i.getAndIncrement())
         t.setDaemon(false)
         t
       }

--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -51,7 +51,7 @@ class TickWheelExecutor(wheelSize: Int = 512, tick: Duration = 200.milli) {
   /////////////////////////////////////////////////////
   // new Thread that actually runs the execution.
 
-  private val thread = new Thread(s"TickWheelExecutor: $wheelSize spokes, $tick interval") {
+  private val thread = new Thread(s"blaze-tick-wheel-executor") {
     override def run() {
       cycle(System.currentTimeMillis())
     }


### PR DESCRIPTION
Puts a `blaze-*` prefix on all threads created by blaze for easy identification during profiling.