### PR TITLE
Specify Charset in `String.getBytes` calls

### DIFF
--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
@@ -1,14 +1,14 @@
 package org.http4s.blaze.pipeline.stages
 
 import java.nio.ByteBuffer
-import javax.net.ssl.{SSLEngineResult, SSLEngine}
+import javax.net.ssl.{SSLEngine, SSLEngineResult}
 import SSLEngineResult.HandshakeStatus._
+import java.nio.charset.StandardCharsets
 
 import org.http4s.blaze.pipeline.Command.Connected
 import org.http4s.blaze.pipeline.LeafBuilder
-import org.http4s.blaze.util.{GenericSSLContext, BufferTools}
+import org.http4s.blaze.util.{BufferTools, GenericSSLContext}
 import org.http4s.blaze.util.Execution
-
 import org.specs2.mutable.Specification
 
 import scala.concurrent.duration._
@@ -191,7 +191,8 @@ class SSLStageSpec extends Specification {
     }
   }
 
-  def mkBuffer(str: String): ByteBuffer = ByteBuffer.wrap(str.getBytes())
+  def mkBuffer(str: String): ByteBuffer =
+    ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8))
   
   def mkClientServerEngines(): (SSLEngine, SSLEngine) = {
     val clientEng = GenericSSLContext.clientSSLContext().createSSLEngine()

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/TimeoutHelpers.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/TimeoutHelpers.scala
@@ -4,24 +4,21 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.http4s.blaze.pipeline.Command.{Disconnected, InboundCommand}
 import org.specs2.mutable.Specification
-
 import org.http4s.blaze.pipeline.{Command, LeafBuilder, TailStage}
-
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 
-import scala.concurrent.{Future, Await}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 abstract class TimeoutHelpers extends Specification {
   
   def genDelayStage(timeout: Duration): TimeoutStageBase[ByteBuffer]
 
-  def newBuff = ByteBuffer.wrap("Foo".getBytes())
+  def newBuff = ByteBuffer.wrap("Foo".getBytes(StandardCharsets.UTF_8))
 
   def checkBuff(buff: ByteBuffer) = {
-    val arr = new Array[Byte]("Foo".getBytes().length)
-    buff.get(arr)
-    new String(arr) should_== "Foo"
+    StandardCharsets.UTF_8.decode(buff).toString should_== "Foo"
   }
 
   def checkFuture(f: Future[ByteBuffer], timeout: Duration = 2.seconds) = {

--- a/examples/src/main/scala/org/http4s/blaze/examples/ExampleService.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/ExampleService.scala
@@ -31,7 +31,7 @@ object ExampleService {
             Future.successful {
               if (i < 1000) {
                 i += 1
-                ByteBuffer.wrap(s"i: $i\n".getBytes)
+                ByteBuffer.wrap(s"i: $i\n".getBytes(StandardCharsets.UTF_8))
               }
               else BufferTools.emptyBuffer
             }

--- a/http/src/test/scala/org/http4s/blaze/http/parser/Benchmarks.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/parser/Benchmarks.scala
@@ -1,10 +1,10 @@
 package org.http4s.blaze.http.parser
 
 import scala.language.reflectiveCalls
-
 import java.nio.ByteBuffer
-import scala.collection.mutable.ListBuffer
+import java.nio.charset.StandardCharsets
 
+import scala.collection.mutable.ListBuffer
 import org.specs2.mutable._
 
 class Benchmarks extends Specification {
@@ -77,7 +77,7 @@ class Benchmarks extends Specification {
     }
 
 
-    val b = ByteBuffer.wrap(mockChunked.getBytes())
+    val b = ByteBuffer.wrap(mockChunked.getBytes(StandardCharsets.UTF_8))
     val blim = b.limit()
     val reconstructed = body + ", " + body + " again!"
 
@@ -119,7 +119,7 @@ class Benchmarks extends Specification {
 
   def rawBenchmark(iterations: Int): Unit = {
     val p = new BenchParser()
-    val b = ByteBuffer.wrap(mockChunked.getBytes())
+    val b = ByteBuffer.wrap(mockChunked.getBytes(StandardCharsets.UTF_8))
 
     def iteration(remaining: Int): Unit = if (remaining > 0) {
       b.position(0)
@@ -156,7 +156,7 @@ class Benchmarks extends Specification {
         super.reset()
       }
     }
-    val b = ByteBuffer.wrap(mockChunked.getBytes())
+    val b = ByteBuffer.wrap(mockChunked.getBytes(StandardCharsets.UTF_8))
 
     def iteration(remaining: Int): Unit = if (remaining > 0) {
       b.position(0)

--- a/http/src/test/scala/org/http4s/blaze/http/parser/ParserBaseSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/parser/ParserBaseSpec.scala
@@ -1,6 +1,7 @@
 package org.http4s.blaze.http.parser
 
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 
 import org.http4s.blaze.http.parser.BaseExceptions.BadCharacter
 import org.specs2.mutable.Specification
@@ -14,7 +15,7 @@ class ParserBaseSpec extends Specification {
 
   "ParserBase.next" should {
     "Provide the next valid char" in {
-      val buffer = ByteBuffer.wrap("OK".getBytes)
+      val buffer = ByteBuffer.wrap("OK".getBytes(StandardCharsets.UTF_8))
         new Base().next(buffer, false) must_== 'O'.toByte
     }
 

--- a/http/src/test/scala/org/http4s/blaze/http/parser/ServerParserSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/parser/ServerParserSpec.scala
@@ -215,7 +215,7 @@ class ServerParserSpec extends Specification {
 
     "Parse a full request" in {
       val p = new Parser()
-      val b = ByteBuffer.wrap(mockFiniteLength.getBytes())
+      val b = strToBuffer(mockFiniteLength)
 
       p.parseLine(b) should_== (true)
 
@@ -234,7 +234,7 @@ class ServerParserSpec extends Specification {
 
     "Parse a full request in fragments" in {
       val p = new Parser()
-      val b = ByteBuffer.wrap(mockFiniteLength.getBytes())
+      val b = strToBuffer(mockFiniteLength)
 
       val blim = b.limit()
 
@@ -260,7 +260,7 @@ class ServerParserSpec extends Specification {
 
     "Parse a chunked request" in {
       val p = new Parser()
-      val b = ByteBuffer.wrap(mockChunked.getBytes())
+      val b = strToBuffer(mockChunked)
 
       p.parseLine(b) should_== (true)
 
@@ -280,7 +280,7 @@ class ServerParserSpec extends Specification {
     "Parse a chunked request with trailers" in {
       val p = new Parser()
       val req = mockChunked.substring(0, mockChunked.length - 2) + "Foo\r\n\r\n"
-      val b = ByteBuffer.wrap(req.getBytes())
+      val b = strToBuffer(req)
 
       println(mockChunked)
 
@@ -303,7 +303,7 @@ class ServerParserSpec extends Specification {
 
     "Give parse a chunked request in fragments" in {
       val p = new Parser()
-      val b = ByteBuffer.wrap(mockChunked.getBytes())
+      val b = strToBuffer(mockChunked)
       val blim = b.limit()
 
       // Do it one char at a time /////////////////////////////////////////
@@ -334,7 +334,7 @@ class ServerParserSpec extends Specification {
     "Give parse a chunked request in fragments with a trailer" in {
       val p = new Parser()
       val req = mockChunked.substring(0, mockChunked.length - 2) + "Foo\r\n\r\n"
-      val b = ByteBuffer.wrap(req.getBytes())
+      val b = strToBuffer(req)
       val blim = b.limit()
 
       // Do it one char at a time /////////////////////////////////////////


### PR DESCRIPTION
Not specifying it means you get a platform specific `Charset`.