### PR TITLE
catch exceptions in NIO2SocketServerGroup

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
@@ -61,10 +61,19 @@ final class NIO1SocketServerGroup private(
   t.start()
 
   override def closeGroup(): Unit = {
-    logger.info("Closing NIO1SocketServerGroup")
-    isClosed = true
-    s.wakeup()
-    ()
+    val wake = synchronized {
+      if (isClosed) false
+      else {
+        logger.info("Closing NIO1SocketServerGroup")
+        isClosed = true
+        true
+      }
+    }
+
+    if (wake) {
+      s.wakeup()
+      ()
+    }
   }
 
 


### PR DESCRIPTION
Closes #111 

If we don't catch exceptions in AsynchronousSocketChannel
we could lose them since the loop is happening asynchronously.

Reported in #97