### PR TITLE
Remote Http2ClientConnection and cleanup some interfaces

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/BasicTail.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/BasicTail.scala
@@ -1,36 +1,5 @@
 package org.http4s.blaze.pipeline.stages
 
-import org.http4s.blaze.pipeline.Command._
 import org.http4s.blaze.pipeline.TailStage
-import org.log4s.getLogger
 
-import scala.concurrent.{Future, Promise}
-
-class BasicTail[T](val name: String) extends TailStage[T] {
-
-  private[this] val log = getLogger
-  private[this] val closeP = Promise[Unit]
-  private[this] val startP = Promise[Unit]
-
-  def onClose: Future[Unit] = closeP.future
-
-  def started: Future[Unit] = startP.future
-
-  def close(): Unit = sendOutboundCommand(Disconnect)
-
-  override def inboundCommand(cmd: InboundCommand): Unit = cmd match {
-    case Connected =>
-      startP.trySuccess(())
-      ()
-
-    case Disconnected | EOF =>
-      closeP.trySuccess(())
-      ()
-
-    case other =>
-      val exc = new IllegalStateException(s"Unknown command: $other")
-      log.warn(exc)("Unknown command")
-      closeP.tryFailure(exc)
-      ()
-  }
-}
+final class BasicTail[T](val name: String) extends TailStage[T]

--- a/http/src/main/scala/org/http4s/blaze/http/HttpClientSession.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/HttpClientSession.scala
@@ -51,6 +51,9 @@ trait Http2ClientSession extends HttpClientSession {
     *         the session. The scale is intended to be linear.
     */
   def quality: Double
+
+  /** Ping the peer, asynchronously returning the duration of the round trip */
+  def ping(): Future[Duration]
 }
 
 object HttpClientSession {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SessionFlowControlImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SessionFlowControlImpl.scala
@@ -177,7 +177,7 @@ private class SessionFlowControlImpl(
       }
     }
 
-    override def peerSettingsInitialWindowChange(delta: Int): MaybeError = {
+    override def remoteSettingsInitialWindowChange(delta: Int): MaybeError = {
       logger.trace(s"Stream($streamId) outbound window adjusted by $delta bytes. $streamWindowString")
       // A sender MUST NOT allow a flow-control window to exceed 2^31-1 octets.
       // https://tools.ietf.org/html/rfc7540#section-6.9.2

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamFlowWindow.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamFlowWindow.scala
@@ -36,7 +36,7 @@ abstract class StreamFlowWindow {
     * @param delta change in intial window size. Maybe be positive or negative, but must not
     *              cause the window to overflow Int.MaxValue.
     */
-  def peerSettingsInitialWindowChange(delta: Int): MaybeError
+  def remoteSettingsInitialWindowChange(delta: Int): MaybeError
 
   /** Signal that a stream window update was received for `count` bytes */
   def streamOutboundAcked(count: Int): MaybeError

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
@@ -41,7 +41,7 @@ private final class StreamManagerImpl(
     val it = streams.valuesIterator
     while (it.hasNext && result == Continue) {
       val stream = it.next()
-      stream.flowWindow.peerSettingsInitialWindowChange(diff) match {
+      stream.flowWindow.remoteSettingsInitialWindowChange(diff) match {
         case Continue =>
           stream.outboundFlowWindowChanged()
 

--- a/http/src/test/scala/org/http4s/blaze/http/ClientSessionManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/ClientSessionManagerImplSpec.scala
@@ -61,6 +61,7 @@ class ClientSessionManagerImplSpec extends Specification {
           closed = true
           Future.successful(())
         }
+        override def ping(): Future[Duration] = ???
         override def status: Status = Closed
         override def quality: Double = 1.0
       }
@@ -68,6 +69,7 @@ class ClientSessionManagerImplSpec extends Specification {
       object lowQuality extends Http2ClientSession {
         override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
         override def close(within: Duration): Future[Unit] = ???
+        override def ping(): Future[Duration] = ???
         override def status: Status = Ready
         override def quality: Double = 0.0
       }
@@ -75,6 +77,7 @@ class ClientSessionManagerImplSpec extends Specification {
       object good extends Http2ClientSession {
         override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
         override def close(within: Duration): Future[Unit] = ???
+        override def ping(): Future[Duration] = ???
         override def status: Status = Ready
         override def quality: Double = 1.0
       }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/Http2FrameEncoderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/Http2FrameEncoderSpec.scala
@@ -33,10 +33,10 @@ class Http2FrameEncoderSpec extends Specification with Mockito with Http2SpecToo
       decoder.decodeBuffer(data2) must_== ReturnTag(2)
     }
 
-    "fragments data frames if they exceed the mySettings.maxFrameSize" >> {
+    "fragments data frames if they exceed the localSettings.maxFrameSize" >> {
       val tools = new MockTools(true)
       val listener = mockListener()
-      val decoder = new Http2FrameDecoder(tools.remoteSettings, listener)
+      val remoteDecoder = new Http2FrameDecoder(tools.remoteSettings, listener)
 
       tools.remoteSettings.maxFrameSize = 10 // technically an illegal size...
 
@@ -45,22 +45,22 @@ class Http2FrameEncoderSpec extends Specification with Mockito with Http2SpecToo
 
       // Frame 1
       listener.onDataFrame(1, false, zeroBuffer(10), 10) returns ReturnTag(1)
-      decoder.decodeBuffer(data1) must_== ReturnTag(1)
+      remoteDecoder.decodeBuffer(data1) must_== ReturnTag(1)
 
       // Frame 2
       listener.onDataFrame(1, true, zeroBuffer(5), 5) returns ReturnTag(2)
-      decoder.decodeBuffer(data1) must_== ReturnTag(2)
+      remoteDecoder.decodeBuffer(data1) must_== ReturnTag(2)
 
       // `endStream = false`
       val data2 = BufferTools.joinBuffers(tools.frameEncoder.dataFrame(1, false, zeroBuffer(15)))
 
       // Frame 1
       listener.onDataFrame(1, false, zeroBuffer(10), 10) returns ReturnTag(3)
-      decoder.decodeBuffer(data2) must_== ReturnTag(3)
+      remoteDecoder.decodeBuffer(data2) must_== ReturnTag(3)
 
       // Frame 2
       listener.onDataFrame(1, false, zeroBuffer(5), 5) returns ReturnTag(4)
-      decoder.decodeBuffer(data2) must_== ReturnTag(4)
+      remoteDecoder.decodeBuffer(data2) must_== ReturnTag(4)
     }
 
     "not fragment headers if they fit into a single frame" >> {

--- a/http/src/test/scala/org/http4s/blaze/http/http2/StreamManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/StreamManagerImplSpec.scala
@@ -2,9 +2,10 @@ package org.http4s.blaze.http.http2
 
 import org.http4s.blaze.http.http2.Http2Exception._
 import org.http4s.blaze.pipeline.Command.EOF
-import org.http4s.blaze.pipeline.{Command, LeafBuilder}
+import org.http4s.blaze.pipeline.{Command, LeafBuilder, TailStage}
 import org.http4s.blaze.pipeline.stages.BasicTail
 import org.specs2.mutable.Specification
+
 import scala.util.Failure
 
 class StreamManagerImplSpec extends Specification {
@@ -14,7 +15,8 @@ class StreamManagerImplSpec extends Specification {
 
     var connects: Int = 0
 
-    lazy val tail = new BasicTail[StreamMessage]("name") {
+    lazy val tail = new TailStage[StreamMessage] {
+      override def name: String = "name"
       override def inboundCommand(cmd: Command.InboundCommand): Unit = {
         if (cmd == Command.Connected) { connects += 1 }
         super.inboundCommand(cmd)

--- a/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockStreamFlowWindow.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockStreamFlowWindow.scala
@@ -8,7 +8,7 @@ private[http2] class MockStreamFlowWindow extends StreamFlowWindow {
   override def outboundRequest(request: Int): Int = ???
   override def streamId: Int = ???
   override def inboundObserved(count: Int): Boolean = ???
-  override def peerSettingsInitialWindowChange(delta: Int): MaybeError = ???
+  override def remoteSettingsInitialWindowChange(delta: Int): MaybeError = ???
   override def streamInboundWindow: Int = ???
   override def streamOutboundWindow: Int = ???
   override def inboundConsumed(count: Int): Unit = ???


### PR DESCRIPTION
We can get by just fine with Http2ClientSession if we add a `ping()`
method.