### PR TITLE
Cleanup of unused and/or redundant abstractions

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -95,7 +95,7 @@ class TickWheelExecutor(wheelSize: Int = 512, tick: Duration = 200.milli) {
     */
   def schedule(r: Runnable, ec: ExecutionContext, timeout: Duration): Cancellable = {
     if (alive) {
-      if (!timeout.isFinite()) {  // This will never timeout, so don't schedule it.
+      if (!timeout.isFinite) {  // This will never timeout, so don't schedule it.
         Cancellable.noopCancel
       }
       else {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/Connection.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/Connection.scala
@@ -54,6 +54,9 @@ private trait Connection {
     */
   // TODO: right now this only benefits the client. We need to get the push-promise support for the server side
   def newOutboundStream(): HeadStage[StreamMessage]
+
+  /** Hook into the shutdown events of the connection */
+  def onClose: Future[Unit]
 }
 
 private object Connection {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/Result.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/Result.scala
@@ -2,7 +2,8 @@ package org.http4s.blaze.http.http2
 
 /** Result type of many of the codec methods */
 private sealed trait Result extends Product with Serializable
-private case object Halt extends Result
+
+/** Didn't get enough data to decode a full HTTP/2 frame */
 private case object BufferUnderflow extends Result
 
 /** Represents the possibility of failure */

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SessionCore.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SessionCore.scala
@@ -1,6 +1,5 @@
 package org.http4s.blaze.http.http2
 
-import org.http4s.blaze.pipeline.LeafBuilder
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
@@ -9,7 +8,7 @@ import scala.concurrent.duration.Duration
   * provides a 'bag-o-references' so that each component can reference each
   * other. This helps to avoid construction order conflicts.
   */
-private trait SessionCore {
+private abstract class SessionCore {
   // Fields
   def serialExecutor: ExecutionContext
 
@@ -32,14 +31,9 @@ private trait SessionCore {
   def pingManager: PingManager
 
   // Properties
-
   def state: Connection.State
 
-  val isClient: Boolean
-
   // Behaviors
-  def newInboundStream(streamId: Int): Option[LeafBuilder[StreamMessage]]
-
   /** Shutdown the session due to unhandled exception
     *
     * This is an emergency shutdown, and the session is in an undefined state.
@@ -48,12 +42,21 @@ private trait SessionCore {
     */
   def invokeShutdownWithError(ex: Option[Throwable], phase: String): Unit
 
-  /** Signal to the session to shutdown gracefully
+  /** Signal to the session to shutdown gracefully based direction from the remote peer
     *
-    * This will entail shutting down the [[StreamManager]] and waiting for
-    * all write interests to drain.
+    * This entails draining the [[StreamManager]] and waiting for all write interests
+    * to drain.
+    *
+    * @see `invokeDrain` for the locally initiated analog
     */
   def invokeGoAway(lastHandledOutboundStream: Int, error: Http2SessionException): Unit
 
+  /** Signal for the session to begin draining based on the direction of the local peer
+    *
+    * This entails draining the [[StreamManager]] and waiting for all write interests
+    * to drain.
+    *
+    * @see `invokeGoAway` for the remote initiated analog
+    */
   def invokeDrain(gracePeriod: Duration): Unit
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SessionFrameListener.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SessionFrameListener.scala
@@ -14,6 +14,7 @@ import org.http4s.blaze.http.http2.Http2Settings.Setting
   */
 private class SessionFrameListener(
     session: SessionCore,
+    isClient: Boolean,
     headerDecoder: HeaderDecoder)
   extends HeaderAggregatingFrameListener(session.localSettings, headerDecoder) {
 
@@ -34,7 +35,7 @@ private class SessionFrameListener(
 
   // See https://tools.ietf.org/html/rfc7540#section-6.6 and section-8.2 for the list of rules
   override def onCompletePushPromiseFrame(streamId: Int, promisedId: Int, headers: Headers): Result = {
-    if (!session.isClient) {
+    if (!isClient) {
       // A client cannot push. Thus, servers MUST treat the receipt of a
       // PUSH_PROMISE frame as a connection error of type PROTOCOL_ERROR.
       // https://tools.ietf.org/html/rfc7540#section-8.2

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
@@ -2,12 +2,14 @@ package org.http4s.blaze.http.http2
 
 import org.http4s.blaze.http._
 import org.http4s.blaze.http.http2.Http2Exception.{PROTOCOL_ERROR, REFUSED_STREAM}
-import org.http4s.blaze.pipeline.Command
+import org.http4s.blaze.pipeline.{Command, LeafBuilder}
+
 import scala.collection.mutable.HashMap
 import scala.concurrent.{Future, Promise}
 
 private final class StreamManagerImpl(
-  session: SessionCore
+  session: SessionCore,
+  inboundStreamBuilder: Option[Int => LeafBuilder[StreamMessage]]
 ) extends StreamManager {
   private[this] val logger = org.log4s.getLogger
   private[this] val streams = new HashMap[Int, StreamState]
@@ -87,7 +89,7 @@ private final class StreamManagerImpl(
           s"Received HEADERS frame for non-idle inbound stream id $streamId"
         }
       Left(PROTOCOL_ERROR.goaway(msg))
-    } else if (session.isClient) {
+    } else if (inboundStreamBuilder.isEmpty) {
       Left(PROTOCOL_ERROR.goaway(
         s"Client received request for new inbound stream ($streamId) without push promise"))
     } else if (drainingP.isDefined) {
@@ -102,18 +104,17 @@ private final class StreamManagerImpl(
       // of error code determines whether the endpoint wishes to enable
       // automatic retry (see Section 8.1.4) for details).
       Left(REFUSED_STREAM.rst(streamId))
-    } else session.newInboundStream(streamId) match {
-      case None => Left(REFUSED_STREAM.rst(streamId))
-      case Some(leafBuilder) =>
-        val streamFlowWindow = session.sessionFlowControl.newStreamFlowWindow(streamId)
-        val streamState = new InboundStreamStateImpl(session, streamId, streamFlowWindow)
-        assert(streams.put(streamId, streamState).isEmpty)
+    } else {
+      val leafBuilder = inboundStreamBuilder.get.apply(streamId) // we already made sure it wasn't empty
+      val streamFlowWindow = session.sessionFlowControl.newStreamFlowWindow(streamId)
+      val streamState = new InboundStreamStateImpl(session, streamId, streamFlowWindow)
+      assert(streams.put(streamId, streamState).isEmpty)
 
-        // assemble the pipeline
-        leafBuilder.base(streamState)
-        streamState.sendInboundCommand(Command.Connected)
+      // assemble the pipeline
+      leafBuilder.base(streamState)
+      streamState.sendInboundCommand(Command.Connected)
 
-        Right(streamState)
+      Right(streamState)
     }
   }
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamStateImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamStateImpl.scala
@@ -220,7 +220,6 @@ private abstract class StreamStateImpl(session: SessionCore) extends StreamState
     } else if (flowWindow.inboundObserved(flowBytes)) {
       receivedEndStream = endStream
       val consumed = if (queueMessage(DataFrame(endStream, data))) flowBytes else flowBytes - data.remaining()
-      println(s"Accepting data! Bytes consume: $consumed")
       flowWindow.inboundConsumed(consumed)
       Continue
     }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/HeaderAggregatingFrameListenerSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/HeaderAggregatingFrameListenerSpec.scala
@@ -12,6 +12,8 @@ class HeaderAggregatingFrameListenerSpec extends Specification {
   import BufferTools._
   import CodecUtils._
 
+  private val Halt = Error(Http2SessionException(-1, "test"))
+
   private def encodeHeaders(hs: Seq[(String, String)]): ByteBuffer =
     new HeaderEncoder(Http2Settings.default.headerTableSize).encodeHeaders(hs)
 

--- a/http/src/test/scala/org/http4s/blaze/http/http2/Http2ExceptionSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/Http2ExceptionSpec.scala
@@ -1,0 +1,14 @@
+package org.http4s.blaze.http.http2
+
+import org.specs2.mutable.Specification
+
+class Http2ExceptionSpec extends Specification {
+  import Http2Exception._
+
+  "Http2Exception" should {
+    "be a connection error for stream id 0" in {
+      PROTOCOL_ERROR.goaway("") must beAnInstanceOf[Http2SessionException]
+      PROTOCOL_ERROR.rst(1, "") must beAnInstanceOf[Http2StreamException]
+    }
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/OutboundStreamStateImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/OutboundStreamStateImplSpec.scala
@@ -22,7 +22,7 @@ class OutboundStreamStateImplSpec extends Specification {
 
       override def state: Connection.State = connectionState
 
-      override lazy val streamManager = new StreamManagerImpl(this)
+      override lazy val streamManager = new StreamManagerImpl(this, None)
     }
 
     lazy val tools = new MockTools

--- a/http/src/test/scala/org/http4s/blaze/http/http2/StreamManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/StreamManagerImplSpec.scala
@@ -10,7 +10,9 @@ import scala.util.Failure
 class StreamManagerImplSpec extends Specification {
 
   private class MockTools(isClient: Boolean) extends mocks.MockTools(isClient) {
-    override lazy val streamManager: StreamManager = new StreamManagerImpl(this)
+    override lazy val streamManager: StreamManager = new StreamManagerImpl(this,
+      if (isClient) None else Some(newInboundStream(_))
+    )
 
     var connects: Int = 0
 
@@ -22,7 +24,7 @@ class StreamManagerImplSpec extends Specification {
       }
     }
 
-    override def newInboundStream(streamId: Int) = Some(LeafBuilder(tail))
+    private def newInboundStream(streamId: Int) = LeafBuilder(tail)
   }
 
   "StreamManagerImpl" should {

--- a/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockTools.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockTools.scala
@@ -7,7 +7,7 @@ import org.http4s.blaze.util.Execution
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 
-private[http2] class MockTools(val isClient: Boolean) extends SessionCore {
+private[http2] class MockTools(isClient: Boolean) extends SessionCore {
 
   def flowStrategy: FlowStrategy = new DefaultFlowStrategy(localSettings)
 
@@ -41,8 +41,6 @@ private[http2] class MockTools(val isClient: Boolean) extends SessionCore {
   override lazy val streamManager: StreamManager = ???
 
   // Behaviors
-  override def newInboundStream(streamId: Int): Option[LeafBuilder[StreamMessage]] = None
-
   override def state: Connection.State = Connection.Running
 
   var drainGracePeriod: Option[Duration] = None


### PR DESCRIPTION
Some general cleanup work including but not limited to:
* Removing the unused `Halt` object
* Defining `isClient` for the SessionCore in terms of having a builder
  for inbound stream.