### PR TITLE
Refactor Settings related parts of codecs and listeners

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http2/FrameDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/FrameDecoder.scala
@@ -177,8 +177,8 @@ private class FrameDecoder(localSettings: Http2Settings, listener: FrameListener
   //////////// SETTINGS ///////////////
   private[this] def decodeSettingsFrame(buffer: ByteBuffer, streamId: Int, flags: Byte): Result = {
     SettingsDecoder.decodeSettingsFrame(buffer, streamId, flags) match {
-      case Right(SettingsFrame(isAck, settings)) =>
-        listener.onSettingsFrame(isAck, settings)
+      case Right(SettingsFrame(settings)) =>
+        listener.onSettingsFrame(settings)
 
       case Left(ex) =>
         Error(ex)

--- a/http/src/main/scala/org/http4s/blaze/http/http2/FrameListener.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/FrameListener.scala
@@ -81,10 +81,10 @@ private trait FrameListener {
     *
     * https://tools.ietf.org/html/rfc7540#section-6.5
     *
-    * @param ack if this was an acknowledgment to an outbound SETTINGS frame
-    * @param settings Settings contained in this frame. If this is an ack, it will always be empty.
+    * @param settings Settings contained in this frame. If this is an ack,
+    *                 `settings` will be `None`.
     */
-  def onSettingsFrame(ack: Boolean, settings: Seq[Setting]): Result
+  def onSettingsFrame(settings: Option[Seq[Setting]]): Result
 
   /** Called on successful receipt of a PUSH_PROMISE frame
     *

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SettingsDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SettingsDecoder.scala
@@ -10,7 +10,13 @@ import org.http4s.blaze.http.http2.bits.{Flags, FrameTypes}
   */
 private object SettingsDecoder {
 
-  case class SettingsFrame(isAck: Boolean, settings: Seq[Setting])
+  /** Representation of a settings frame
+    *
+    * If the frame was an ack, settings is None, else it contains the settings sent by the peer
+    */
+  final case class SettingsFrame(settings: Option[Seq[Setting]]) {
+    def isAck: Boolean = settings.isEmpty
+  }
 
   /** Decode a settings frame
     *
@@ -44,48 +50,36 @@ private object SettingsDecoder {
     val isAck = Flags.ACK(flags)
 
     if (len % 6 != 0) { // Invalid frame size
-    val msg = s"SETTINGS frame payload must be multiple of 6 bytes, size: $len"
-      return Left(FRAME_SIZE_ERROR.goaway(msg))
-    }
-
-    val settingsCount = len / 6 // 6 bytes per setting
-
-    if (isAck && settingsCount != 0) {
+      val msg = s"SETTINGS frame payload must be multiple of 6 bytes, size: $len"
+      Left(FRAME_SIZE_ERROR.goaway(msg))
+    } else if (isAck && len != 0) {
+      val settingsCount = len / 6 // 6 bytes per setting
       val msg = s"SETTINGS ACK frame with settings payload ($settingsCount settings)"
-      return Left(FRAME_SIZE_ERROR.goaway(msg))
+      Left(FRAME_SIZE_ERROR.goaway(msg))
+    } else if (streamId != 0x0) {
+      Left(PROTOCOL_ERROR.goaway(s"SETTINGS frame with invalid stream id: $streamId"))
+    } else Right {
+      // We have a valid frame
+      if (isAck) SettingsFrame(None)
+      else {
+        val settings = Vector.newBuilder[Setting]
+        while(buffer.hasRemaining) {
+          val id: Int = buffer.getShort() & 0xffff
+          val value = buffer.getInt()
+          settings += Setting(id, value)
+        }
+
+        SettingsFrame(Some(settings.result))
+      }
     }
-
-    if (streamId != 0x0) {
-      return Left(PROTOCOL_ERROR.goaway(s"SETTINGS frame with invalid stream id: $streamId"))
-    }
-
-    val settings = Vector.newBuilder[Setting]
-
-    while(buffer.hasRemaining) {
-      val id: Int = buffer.getShort() & 0xffff
-      val value = buffer.getInt()
-      settings += Setting(id, value)
-    }
-
-    Right(SettingsFrame(isAck, settings.result))
   }
 
   /** Create a [[MutableHttp2Settings]] from a collection of settings */
-  def settingsFromFrame(settings: Seq[Setting]): MutableHttp2Settings = {
+  def settingsFromFrame(settings: Seq[Setting]): Either[Http2Exception, MutableHttp2Settings] = {
     val next = MutableHttp2Settings.default()
-    updateSettings(next, settings)
-    next
-  }
-
-  private[this] def updateSettings(settings: MutableHttp2Settings, next: Seq[Setting]): Unit = {
-    import Http2Settings._
-    next.foreach {
-      case HEADER_TABLE_SIZE(size)      => settings.headerTableSize = size.toInt
-      case ENABLE_PUSH(enabled)         => settings.pushEnabled = enabled != 0
-      case MAX_CONCURRENT_STREAMS(max)  => settings.maxConcurrentStreams = max.toInt
-      case INITIAL_WINDOW_SIZE(size)    => settings.initialWindowSize = size.toInt
-      case MAX_FRAME_SIZE(size)         => settings.maxFrameSize = size.toInt
-      case MAX_HEADER_LIST_SIZE(size)   => settings.maxHeaderListSize = size.toInt
+    next.updateSettings(settings) match {
+      case None => Right(next)
+      case Some(ex) => Left(ex)
     }
   }
 }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/FrameDecoderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/FrameDecoderSpec.scala
@@ -546,10 +546,8 @@ class FrameDecoderSpec extends Specification {
 
   "SETTINGS" >> {
     class SettingsListener extends MockFrameListener(false) {
-      var ack: Option[Boolean] = None
-      var settings: Option[Seq[Setting]] = None
-      override def onSettingsFrame(ack: Boolean, settings: Seq[Setting]): Result = {
-        this.ack = Some(ack)
+      var settings: Option[Option[Seq[Setting]]] = None
+      override def onSettingsFrame(settings: Option[Seq[Setting]]): Result = {
         this.settings = Some(settings)
         Continue
       }
@@ -574,8 +572,7 @@ class FrameDecoderSpec extends Specification {
       val dec = new FrameDecoder(Http2Settings.default, listener)
 
       dec.decodeBuffer(testData) must_== Continue
-      listener.ack must beSome(false)
-      listener.settings must_== Some(Seq.empty[Setting])
+      listener.settings must_== Some(Some(Seq.empty[Setting]))
     }
 
     "simple frame ack" >> {
@@ -591,8 +588,7 @@ class FrameDecoderSpec extends Specification {
       val dec = new FrameDecoder(Http2Settings.default, listener)
 
       dec.decodeBuffer(testData) must_== Continue
-      listener.ack must beSome(true)
-      listener.settings must_== Some(Seq.empty[Setting])
+      listener.settings must_== Some(None)
     }
 
     "simple frame with settings" >> {
@@ -610,8 +606,7 @@ class FrameDecoderSpec extends Specification {
       val dec = new FrameDecoder(Http2Settings.default, listener)
 
       dec.decodeBuffer(testData) must_== Continue
-      listener.ack must beSome(false)
-      listener.settings must_== Some(Seq(Setting(0, 1)))
+      listener.settings must_== Some(Some(Seq(Setting(0, 1))))
     }
 
     "streamid != 0" >> {

--- a/http/src/test/scala/org/http4s/blaze/http/http2/ProtocolFrame.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/ProtocolFrame.scala
@@ -1,5 +1,7 @@
 package org.http4s.blaze.http.http2
 
+import org.http4s.blaze.http.http2.Http2Settings.Setting
+
 // TODO: these may form the basis of what gets written to the WriteListener
 sealed abstract class ProtocolFrame private extends Product with Serializable
 
@@ -7,6 +9,8 @@ object ProtocolFrame {
   case class GoAway(lastHandleStream: Int, cause: Http2Exception) extends ProtocolFrame
 
   case class Ping(data: Option[Array[Byte]]) extends ProtocolFrame
+
+  case class Settings(settings: Option[Seq[Setting]]) extends ProtocolFrame
 
   case object Empty extends ProtocolFrame
 }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/ProtocolFrameDecoder.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/ProtocolFrameDecoder.scala
@@ -3,6 +3,7 @@ package org.http4s.blaze.http.http2
 import java.nio.charset.StandardCharsets
 import java.nio.ByteBuffer
 
+import org.http4s.blaze.http.http2.Http2Settings.Setting
 import org.http4s.blaze.http.http2.mocks.MockFrameListener
 
 private object ProtocolFrameDecoder {
@@ -18,6 +19,11 @@ private object ProtocolFrameDecoder {
 
     override def onPingFrame(ack: Boolean, data: Array[Byte]): Result = {
       frame = ProtocolFrame.Ping(if (ack) None else Some(data))
+      Continue
+    }
+
+    override def onSettingsFrame(settings: Option[Seq[Setting]]): Result = {
+      frame = ProtocolFrame.Settings(settings)
       Continue
     }
   }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/SessionFrameListenerSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/SessionFrameListenerSpec.scala
@@ -243,7 +243,7 @@ class SessionFrameListenerSpec extends Specification {
       "Updates remote settings" >> {
         val tools = new MockTools(true)
         val settingChange = Http2Settings.INITIAL_WINDOW_SIZE(1)
-        tools.frameListener.onSettingsFrame(false, Seq(settingChange)) must_== Continue
+        tools.frameListener.onSettingsFrame(Some(Seq(settingChange))) must_== Continue
 
         // Should have changed the setting
         tools.remoteSettings.initialWindowSize must_== 1

--- a/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockFrameListener.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockFrameListener.scala
@@ -13,7 +13,7 @@ private[http2] class MockFrameListener(inHeaders: Boolean) extends FrameListener
 
   // For handling unknown stream frames
   override def onHeadersFrame(streamId: Int, priority: Priority, end_headers: Boolean, end_stream: Boolean, buffer: ByteBuffer): Result = ???
-  override def onSettingsFrame(ack: Boolean, settings: Seq[Setting]): Result = ???
+  override def onSettingsFrame(settings: Option[Seq[Setting]]): Result = ???
   override def onRstStreamFrame(streamId: Int, code: Long): Result = ???
   override def onPriorityFrame(streamId: Int, priority: Priority.Dependent): Result = ???
   override def onContinuationFrame(streamId: Int, endHeaders: Boolean, data: ByteBuffer): Result = ???

--- a/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockHeaderAggregatingFrameListener.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockHeaderAggregatingFrameListener.scala
@@ -13,7 +13,7 @@ private[http2] class MockHeaderAggregatingFrameListener extends HeaderAggregatin
   override def onCompleteHeadersFrame(streamId: Int, priority: Priority, end_stream: Boolean, headers: Headers): Result = ???
   override def onGoAwayFrame(lastStream: Int, errorCode: Long, debugData: Array[Byte]): Result = ???
   override def onPingFrame(ack: Boolean, data: Array[Byte]): Result = ???
-  override def onSettingsFrame(ack: Boolean, settings: Seq[Setting]): Result = ???
+  override def onSettingsFrame(settings: Option[Seq[Setting]]): Result = ???
 
   // For handling unknown stream frames
   override def onRstStreamFrame(streamId: Int, code: Long): Result = ???


### PR DESCRIPTION
Since an ack and settings are mutually exclusive, we can model it
better as Settings(Option[Seq[Setting]]) where None represents an ack
and Some represents a settings frame.