### PR TITLE
Add ClientStage and ClientSessionImpl

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/HttpRequest.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/HttpRequest.scala
@@ -8,4 +8,11 @@ package org.http4s.blaze.http
   * @param body function which returns the next chunk of the request body. Termination is
   *             signaled by an __empty__ `ByteBuffer` as determined by `ByteBuffer.hasRemaining()`.
   */
-case class HttpRequest(method: Method, url: Url, majorVersion: Int, minorVersion: Int, headers: Headers, body: BodyReader)
+case class HttpRequest(
+  method: Method,
+  url: Url,
+  majorVersion: Int,
+  minorVersion: Int,
+  headers: Headers,
+  body: BodyReader
+)

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
@@ -1,6 +1,7 @@
 package org.http4s.blaze.http.http2.client
 
 import java.nio.ByteBuffer
+import java.util.Locale
 
 import org.http4s.blaze.http.{ClientResponse, _}
 import org.http4s.blaze.http.HttpClientSession.ReleaseableResponse
@@ -187,7 +188,7 @@ private object ClientStage {
 
       // Header keys need to be lower cased
       request.headers.foreach { case p @ (k, v) =>
-        val lowerKey = k.toLowerCase
+        val lowerKey = k.toLowerCase(Locale.ENGLISH)
         if (lowerKey eq k) hs += p
         else hs += lowerKey -> v
       }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
@@ -1,0 +1,198 @@
+package org.http4s.blaze.http.http2.client
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.{ClientResponse, _}
+import org.http4s.blaze.http.HttpClientSession.ReleaseableResponse
+import org.http4s.blaze.http.util.UrlTools.UrlComposition
+import org.http4s.blaze.http.http2._
+import org.http4s.blaze.pipeline.Command.{Disconnect, OutboundCommand}
+import org.http4s.blaze.pipeline.{Command, TailStage}
+import org.http4s.blaze.util.{BufferTools, Execution}
+
+import scala.collection.immutable.VectorBuilder
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
+
+private class ClientStage(request: HttpRequest) extends TailStage[StreamMessage] {
+  import ClientStage._
+
+  private[this] val lock: Object = this
+
+  private[this] var inboundEOF = false
+  private[this] var released = false
+
+  // there is no handle to detect when the request body has been written, and,
+  // in general, we should not expect to receive the full response before the
+  // full request has been written.
+  private[this] def release(cmd: OutboundCommand): Unit = lock.synchronized {
+    if (!released) {
+      released = true
+      inboundEOF = true
+      sendOutboundCommand(cmd)
+    }
+  }
+
+  private[this] def inboundConsumed: Boolean = lock.synchronized { inboundEOF }
+
+  private[this] def observeEOF(): Unit = lock.synchronized { inboundEOF = true }
+
+  private class ReleasableResponseImpl(
+      code: Int, status: String, headers: Headers, body: BodyReader)
+    extends ClientResponse(code, status, headers, body) with ReleaseableResponse {
+    override def release(): Unit = ClientStage.this.release(Command.Disconnect)
+  }
+
+  override def name: String = "Http2ClientTail"
+
+  private[this] val _result = Promise[ReleaseableResponse]
+
+  def result: Future[ReleaseableResponse] = _result.future
+
+  override protected def stageStartup(): Unit = makeHeaders(request) match {
+    case Failure(t) =>
+      shutdownWithError(t, "Failed to construct a valid request")
+
+    case Success(hs) =>
+      val eos = request.body.isExhausted
+      val headerFrame = HeadersFrame(Priority.NoPriority, eos, hs)
+
+      channelWrite(headerFrame).onComplete {
+        case Success(_) =>
+          if (!eos) {
+            writeBody(request.body)
+          }
+          readResponseHeaders()
+
+        case Failure(ex) => shutdownWithError(ex, "writeHeaders")
+      }(Execution.directec)
+  }
+
+  private def writeBody(body: BodyReader): Unit = {
+    def go(): Future[Unit] = {
+      body().flatMap { b =>
+        val eos = b.hasRemaining
+        val frame = DataFrame(eos, b)
+        val f = channelWrite(frame)
+        if (!eos) f.flatMap(_ => go())(Execution.trampoline)
+        else f
+      }(Execution.trampoline)
+    }
+
+    // The body writing computation is orphaned: if it completes that great, if not
+    // that's also fine. Errors should be propagated via the response or errors.
+    go().onComplete { _ => body.discard() }(Execution.directec)
+  }
+
+  private def readResponseHeaders(): Unit = channelRead().onComplete {
+    case Success(HeadersFrame(_, eos, hs)) =>
+      val body = if (eos) BodyReader.EmptyBodyReader else new BodyReaderImpl
+      // TODO: we need to make sure this wasn't a 1xx response
+      collectResponseFromHeaders(body, hs) match {
+        case s @ Success(_) => _result.tryComplete(s)
+        case Failure(ex) => shutdownWithError(ex, "readResponseHeaders")
+      }
+
+    case Success(other) =>
+      // The first frame must be a HEADERS frame, either of an informational
+      // response or the message prelude
+      // https://tools.ietf.org/html/rfc7540#section-8.1
+      val ex = new IllegalStateException(s"HTTP2 response started with message other than headers: $other")
+      shutdownWithError(ex, "readResponseHeaders")
+
+    case Failure(ex) => shutdownWithError(ex, "readResponseHeaders")
+  }(Execution.trampoline)
+
+  private[this] class BodyReaderImpl extends BodyReader {
+    // We don't want to call `release()` here because we may be waiting for this message
+    // to be written, so we don't want to close the stream
+    override def discard(): Unit = observeEOF()
+
+    override def isExhausted: Boolean = inboundConsumed
+
+    override def apply(): Future[ByteBuffer] = {
+      if (inboundConsumed) BufferTools.emptyFutureBuffer
+      else channelRead().map {
+        case d@DataFrame(eos, data) =>
+          if (eos) discard()
+          logger.debug(s"Received data frame: $d")
+          data
+
+        case other =>
+          logger.debug(s"Received frame other than data: $other. Discarding remainder of body.")
+          discard()
+          BufferTools.emptyBuffer
+      }(Execution.directec)
+    }
+  }
+
+  private def collectResponseFromHeaders(body: BodyReader, hs: Seq[(String, String)]): Try[ReleaseableResponse] = {
+    logger.debug(s"Received response headers: $hs")
+
+    val regularHeaders = new VectorBuilder[(String, String)]
+    var pseudos = true
+    var statusCode = -1
+
+    val it = hs.iterator
+    while (it.hasNext) {
+      val pair@(k, v) = it.next()
+
+      if (!k.startsWith(":")) {
+          pseudos = false // definitely not in pseudos anymore
+          regularHeaders += pair
+      } else if (!pseudos) {
+        return Failure(new Exception("Pseudo headers were not contiguous"))
+      } else k match {
+          // Matching on pseudo headers now
+        case StageTools.Status =>
+          if (statusCode != -1)
+            return Failure(new Exception("Multiple status code HTTP2 pseudo headers detected in response"))
+
+          try statusCode = v.toInt
+          catch { case ex: NumberFormatException => return Failure(ex) }
+
+        case _ => // don't care about other pseudo headers at this time
+      }
+    }
+
+    if (statusCode != -1) Success(new ReleasableResponseImpl(statusCode, "UNKNOWN", regularHeaders.result(), body))
+    else {
+      val ex = Http2Exception.PROTOCOL_ERROR.rst(-1, "HTTP2 Response headers didn't include a status code.")
+      release(Command.Error(ex))
+      Failure(ex)
+    }
+  }
+
+  private[this] def shutdownWithError(ex: Throwable, phase: String): Unit = {
+    logger.debug(ex)(s"$name shutting down due to error in phase $phase")
+    if (_result.tryFailure(ex)) {
+      // Since the user won't be getting a `ReleasableResponse`, it is our job
+      // to close down the stream.
+      val command = if (ex == Command.EOF) Disconnect else Command.Error(ex)
+      release(command)
+    }
+  }
+}
+
+private object ClientStage {
+  private[client] def makeHeaders(request: HttpRequest): Try[Vector[(String, String)]] = {
+    UrlComposition(request.url).map { breakdown =>
+      val hs = new VectorBuilder[(String, String)]
+
+      // h2 pseudo headers
+      hs += StageTools.Method -> request.method.toUpperCase
+      hs += StageTools.Scheme -> breakdown.scheme
+      hs += StageTools.Authority -> breakdown.authority
+      hs += StageTools.Path -> breakdown.fullPath
+
+      // Header keys need to be lower cased
+      request.headers.foreach { case p @ (k, v) =>
+        val lowerKey = k.toLowerCase
+        if (lowerKey eq k) hs += p
+        else hs += lowerKey -> v
+      }
+
+      hs.result()
+    }
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/ClientPriorKnowledgeHandshakerSpecSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/ClientPriorKnowledgeHandshakerSpecSpec.scala
@@ -1,7 +1,7 @@
 package org.http4s.blaze.http.http2
 
 import org.http4s.blaze.http.http2.client.ClientPriorKnowledgeHandshaker
-import org.http4s.blaze.http.http2.mocks.MockHeadStage
+import org.http4s.blaze.http.http2.mocks.MockByteBufferHeadStage
 import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.blaze.util.Execution
 import org.specs2.mutable.Specification
@@ -21,20 +21,20 @@ class ClientPriorKnowledgeHandshakerSpec extends Specification {
   "ClientPriorKnowledgeHandshaker">> {
     "can perform a handshake" in {
       val localSettings = Http2Settings.default
-      val head = new MockHeadStage
+      val head = new MockByteBufferHeadStage
       val handshaker = makeHandshaker(localSettings)
       LeafBuilder(handshaker).base(head)
       head.sendInboundCommand(Command.Connected)
 
       // Consume all the inbound data which may be a prelude and the local settings
-      head.consumeOutboundData()
-      head.consumeOutboundData()
+      head.consumeOutboundByteBuf()
+      head.consumeOutboundByteBuf()
 
       // Send in a settings frame
       val frame = FrameSerializer.mkSettingsFrame(Seq.empty)
       head.reads.dequeue().success(frame)
 
-      ProtocolFrameDecoder.decode(head.consumeOutboundData()) must beLike {
+      ProtocolFrameDecoder.decode(head.consumeOutboundByteBuf()) must beLike {
         case ProtocolFrame.Settings(None) => ok // should have sent an ack
       }
 
@@ -44,34 +44,34 @@ class ClientPriorKnowledgeHandshakerSpec extends Specification {
     }
 
     "Sends settings" in {
-      val head = new MockHeadStage
+      val head = new MockByteBufferHeadStage
       val settings = Http2Settings.default
       val tail = makeHandshaker(settings)
       LeafBuilder(tail).base(head)
       head.sendInboundCommand(Command.Connected)
 
-      head.consumeOutboundData() must_== bits.getPrefaceBuffer()
-      ProtocolFrameDecoder.decode(head.consumeOutboundData()) must beLike {
+      head.consumeOutboundByteBuf() must_== bits.getPrefaceBuffer()
+      ProtocolFrameDecoder.decode(head.consumeOutboundByteBuf()) must beLike {
         case ProtocolFrame.Settings(Some(_)) => ok
       }
     }
 
     "Sends a GOAWAY(PROTOCOL_ERROR) if settings frame that exceeds the local MAX_FRAME_SIZE" in {
       val localSettings = Http2Settings.default.copy(maxFrameSize = 0)
-      val head = new MockHeadStage
+      val head = new MockByteBufferHeadStage
       val handshaker = makeHandshaker(localSettings)
       LeafBuilder(handshaker).base(head)
       head.sendInboundCommand(Command.Connected)
 
       // Consume all the inbound data which may be a prelude and the local settings
-      head.consumeOutboundData()
-      head.consumeOutboundData()
+      head.consumeOutboundByteBuf()
+      head.consumeOutboundByteBuf()
 
       // Send in a settings frame that is guarenteed to break the limit
       val frame = FrameSerializer.mkSettingsFrame(Seq(Http2Settings.HEADER_TABLE_SIZE(3)))
       head.reads.dequeue().success(frame)
 
-      ProtocolFrameDecoder.decode(head.consumeOutboundData()) must beLike {
+      ProtocolFrameDecoder.decode(head.consumeOutboundByteBuf()) must beLike {
         case ProtocolFrame.GoAway(0, cause) => cause.code must_== Http2Exception.FRAME_SIZE_ERROR.code
       }
 
@@ -84,20 +84,20 @@ class ClientPriorKnowledgeHandshakerSpec extends Specification {
 
     "Sends a GOAWAY(PROTOCOL_ERROR) if the first frame isn't a settings frame" in {
       val localSettings = Http2Settings.default
-      val head = new MockHeadStage
+      val head = new MockByteBufferHeadStage
       val handshaker = makeHandshaker(localSettings)
       LeafBuilder(handshaker).base(head)
       head.sendInboundCommand(Command.Connected)
 
       // Consume all the inbound data which may be a prelude and the local settings
-      head.consumeOutboundData()
-      head.consumeOutboundData()
+      head.consumeOutboundByteBuf()
+      head.consumeOutboundByteBuf()
 
       // Send in a non-settings frame
       val frame = FrameSerializer.mkRstStreamFrame(1, 1)
       head.reads.dequeue().success(frame)
 
-      ProtocolFrameDecoder.decode(head.consumeOutboundData()) must beLike {
+      ProtocolFrameDecoder.decode(head.consumeOutboundByteBuf()) must beLike {
         case ProtocolFrame.GoAway(0, cause) => cause.code must_== Http2Exception.PROTOCOL_ERROR.code
       }
 

--- a/http/src/test/scala/org/http4s/blaze/http/http2/client/ClientStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/client/ClientStageSpec.scala
@@ -1,0 +1,166 @@
+package org.http4s.blaze.http.http2.client
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.http2._
+import org.http4s.blaze.http.http2.mocks.MockHeadStage
+import org.http4s.blaze.http.{BodyReader, HttpRequest}
+import org.http4s.blaze.pipeline.{Command, LeafBuilder}
+import org.http4s.blaze.util.{BufferTools, Execution}
+import org.specs2.mutable.Specification
+
+import scala.util.{Failure, Success, Try}
+
+class ClientStageSpec extends Specification {
+
+  private val request = HttpRequest(
+    method = "GET",
+    url = "https://foo.com/Foo?Bar",
+    majorVersion = 2,
+    minorVersion = 0,
+    headers = Seq("Not-Lower-Case" -> "Value"),
+    body = BodyReader.EmptyBodyReader
+  )
+
+  private val resp = HeadersFrame(
+    priority = Priority.NoPriority,
+    endStream = true,
+    headers = Seq(StageTools.Status -> "200")
+  )
+
+  "ClientStage" >> {
+    "make appropriate pseudo headers" >> {
+      ClientStage.makeHeaders(request) must_== Try(Vector(
+        StageTools.Method -> "GET",
+        StageTools.Scheme -> "https",
+        StageTools.Authority -> "foo.com",
+        StageTools.Path -> "/Foo?Bar",
+        "not-lower-case" -> "Value"
+      ))
+    }
+
+    "Mark the first HEADERS frame as EOS if there isn't a body" >> {
+      val cs = new ClientStage(request)
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+
+      val (HeadersFrame(_, eos, _), _) = head.writes.dequeue()
+      eos must beTrue
+    }
+
+    "Not mark the first HEADERS frame EOS if there is a body" >> {
+      val body = BodyReader.singleBuffer(ByteBuffer.allocate(1))
+      val cs = new ClientStage(request.copy(body = body))
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+
+      val (HeadersFrame(_, eos, _), _) = head.writes.dequeue()
+      eos must beFalse
+    }
+
+    "Write a body to the pipeline and mark the last frame EOS" >> {
+      val d = ByteBuffer.allocate(1)
+      val body = BodyReader.singleBuffer(d)
+      val cs = new ClientStage(request.copy(body = body))
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+
+      val Seq(HeadersFrame(_, false, _)) = head.consumeOutboundData()
+      val Seq(DataFrame(eos, data)) = head.consumeOutboundData()
+      eos must beTrue
+      data must_== d // should be referentially equal
+    }
+
+    "Response will have an empty body if the first inbound frame is marked EOS" >> {
+      val cs = new ClientStage(request)
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+
+      val Seq(HeadersFrame(_, true, _)) = head.consumeOutboundData()
+      head.reads.dequeue().success(resp)
+
+      // available since all these tests execute single threaded
+      val Some(Success(response)) = cs.result.value
+      response.body.isExhausted must beTrue
+    }
+
+    "Responses with a body can have the body available through the reader" >> {
+      val cs = new ClientStage(request)
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+
+      val Seq(HeadersFrame(_, true, _)) = head.consumeOutboundData()
+      head.reads.dequeue().success(resp.copy(endStream = false))
+
+      // available since all these tests execute single threaded
+      val Some(Success(response)) = cs.result.value
+      response.body.isExhausted must beFalse
+
+      val f = response.body()
+      f.isCompleted must beFalse
+
+      val d = BufferTools.allocate(10)
+      head.reads.dequeue().success(DataFrame(true, d))
+
+      val Some(Success(data)) = f.value
+      data must_== d
+      response.body.isExhausted must beTrue
+    }
+
+    "Releasing the response will send a disconnect message" >> {
+      val cs = new ClientStage(request)
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+      val Seq(HeadersFrame(_, true, _)) = head.consumeOutboundData()
+      head.reads.dequeue().success(resp)
+
+      val Some(Success(r)) = cs.result.value
+      r.release()
+
+      head.disconnected must beTrue
+    }
+
+    "Failure of writing the request prelude results in a disconnect" >> {
+      val cs = new ClientStage(request)
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+      val (_, writeP) = head.writes.dequeue()
+      writeP.failure(Command.EOF)
+
+      head.disconnected must beTrue
+      cs.result.value must beLike {
+        case Some(Failure(Command.EOF)) => ok
+      }
+    }
+
+    "Failure to read the response results in a disconnect" >> {
+      val cs = new ClientStage(request)
+      val head = new MockHeadStage[StreamMessage]
+      LeafBuilder(cs).base(head)
+
+      head.sendInboundCommand(Command.Connected)
+      val Seq(HeadersFrame(_, true, _)) = head.consumeOutboundData()
+      head.reads.dequeue().failure(Command.EOF)
+
+      head.disconnected must beTrue
+      cs.result.value must beLike {
+        case Some(Failure(Command.EOF)) => ok
+      }
+    }
+  }
+
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockByteBufferHeadStage.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockByteBufferHeadStage.scala
@@ -1,0 +1,21 @@
+package org.http4s.blaze.http.http2.mocks
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.pipeline.Command.OutboundCommand
+import org.http4s.blaze.pipeline.Command
+import org.http4s.blaze.util.BufferTools
+
+private[http2] class MockByteBufferHeadStage extends MockHeadStage[ByteBuffer] {
+  override def name: String = "Head"
+
+  def consumeOutboundByteBuf(): ByteBuffer =
+    BufferTools.joinBuffers(consumeOutboundData())
+
+  /** Receives outbound commands
+    * Override to capture commands. */
+  override def outboundCommand(cmd: OutboundCommand): Unit = {
+    disconnected = disconnected | (cmd == Command.Disconnect)
+    super.outboundCommand(cmd)
+  }
+}


### PR DESCRIPTION
The ClientStage is responsible for handling the dispatch of a HTTP
request which means turning a request and response into and from a
stream of HTTP/2 messages.

The ClientSessionImpl is just a thin wrapper around the HttpConnection.