### PR TITLE
Add Http2Client and the session manager and selectors necessary

### DIFF
--- a/examples/src/main/scala/org/http4s/blaze/examples/http2/H2ClientExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/http2/H2ClientExample.scala
@@ -1,0 +1,67 @@
+package org.http4s.blaze.examples.http2
+
+import java.nio.charset.StandardCharsets
+
+import org.http4s.blaze.http.HttpClient
+import org.http4s.blaze.http.http2.client.Http2Client
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+
+abstract class H2ClientExample(count: Int, timeout: Duration) {
+
+  protected implicit val ec = scala.concurrent.ExecutionContext.global
+
+  lazy val h2Clients: Array[HttpClient] = Array.tabulate(3){_ => Http2Client.newH2Client() }
+
+  def doCall(tag: Int): Future[Int]
+
+  def main(args: Array[String]): Unit = {
+    println("Hello, world!")
+
+    Await.result(Future.sequence((0 until h2Clients.length).map(doCall)), 5.seconds)
+
+    def fresps(i: Int) = (h2Clients.length until i).map { i =>
+      doCall(i).map(i -> _)
+    }
+
+    Await.result(Future.sequence(fresps(count / 5)), timeout)
+    val start = System.currentTimeMillis
+    val resps = Await.result(Future.sequence(fresps(count)), timeout)
+    val duration = System.currentTimeMillis - start
+
+    val chars = resps.foldLeft(0){ case (acc, (i, len)) =>
+      acc + len
+    }
+
+    println(s"The total body length of ${resps.length} messages: $chars. Took $duration millis")
+  }
+}
+
+object H2GoogleExample extends H2ClientExample(20, 30.seconds) {
+  override def doCall(tag: Int): Future[Int] = callGoogle(tag).map(_.length)
+
+  private[this] def callGoogle(tag: Int): Future[String] = {
+    Http2Client.defaultH2Client.GET("https://www.google.com/") { resp =>
+      resp.body.accumulate().map { bytes =>
+        println(s"Finished response $tag")
+        StandardCharsets.UTF_8.decode(bytes).toString
+      }
+    }
+  }
+}
+
+object H2TwitterExample extends H2ClientExample(20, 30.seconds) {
+  override def doCall(tag: Int): Future[Int] = callTwitter(tag).map(_.length)
+
+  private[this] def callTwitter(tag: Int): Future[String] = {
+    Http2Client.defaultH2Client.GET("https://twitter.com/") { resp =>
+      resp.body.accumulate().map { bytes =>
+
+        println(s"Finished response $tag of size ${bytes.remaining()}: ${resp.headers}")
+        StandardCharsets.UTF_8.decode(bytes).toString
+      }
+    }
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
@@ -48,7 +48,7 @@ trait BodyReader {
     BodyReader.accumulate(max, this)
 }
 
-private object BodyReader {
+object BodyReader {
 
   /** Provides a simple way to proxy a `BodyReader` */
   abstract class Proxy(underlying: BodyReader) extends BodyReader {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ALPNClientSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ALPNClientSelector.scala
@@ -1,0 +1,66 @@
+package org.http4s.blaze.http.http2.client
+
+import java.nio.ByteBuffer
+import java.util
+import javax.net.ssl.SSLEngine
+
+import org.eclipse.jetty.alpn.ALPN
+import org.http4s.blaze.pipeline.{Command => Cmd, LeafBuilder, TailStage}
+import org.http4s.blaze.util.Execution._
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success}
+
+class ALPNClientSelector(
+    engine: SSLEngine,
+    available: Seq[String],
+    default: String,
+    builder: String => LeafBuilder[ByteBuffer])
+  extends TailStage[ByteBuffer] {
+  require(available.nonEmpty)
+
+  ALPN.put(engine, new ClientProvider)
+
+  @volatile
+  private var selected: Option[String] = None
+
+  override def name: String = "Http2ClientALPNSelector"
+
+  override protected def stageStartup(): Unit = {
+    // This shouldn't complete until the handshake is done and ALPN has been run.
+    channelWrite(Nil).onComplete {
+      case Success(_)       => selectPipeline()
+      case Failure(Cmd.EOF) => // NOOP
+      case Failure(t)       =>
+        logger.error(t)(s"$name failed to startup")
+        sendOutboundCommand(Cmd.Error(t))
+    }(trampoline)
+  }
+
+  private def selectPipeline(): Unit = {
+    try {
+      logger.debug(s"Client ALPN selected: $selected")
+      val tail = builder(selected.getOrElse(default))
+      this.replaceTail(tail, true)
+      ()
+    } catch {
+      case t: Throwable =>
+        logger.error(t)("Failure building pipeline")
+        sendOutboundCommand(Cmd.Error(t))
+    }
+  }
+
+  private class ClientProvider extends ALPN.ClientProvider {
+    override val protocols: util.List[String] = available.asJava
+
+    override def unsupported(): Unit = {
+      ALPN.remove(engine)
+      logger.info("ALPN client negotiation failed. Defaulting to head of seq")
+    }
+
+    override def selected(protocol: String): Unit = {
+      ALPN.remove(engine)
+      ALPNClientSelector.this.selected = Some(protocol)
+    }
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientSelector.scala
@@ -1,0 +1,44 @@
+package org.http4s.blaze.http.http2.client
+
+import java.nio.ByteBuffer
+import javax.net.ssl.SSLEngine
+
+import org.http4s.blaze.http.http1.client.Http1ClientStage
+import org.http4s.blaze.http.http2.{DefaultFlowStrategy, Http2Settings, ImmutableHttp2Settings}
+import org.http4s.blaze.http.{ALPNTokens, HttpClientConfig, HttpClientSession}
+import org.http4s.blaze.pipeline.LeafBuilder
+import org.http4s.blaze.util.Execution
+import org.log4s.getLogger
+
+import scala.concurrent.Promise
+
+private[http] class ClientSelector(config: HttpClientConfig) {
+  import ALPNTokens._
+
+  private[this] val logger = getLogger
+
+  def newStage(engine: SSLEngine, p: Promise[HttpClientSession]): ALPNClientSelector =
+    new ALPNClientSelector(engine, AllTokens, HTTP_1_1, buildPipeline(p))
+
+  private[this] val localSettings: ImmutableHttp2Settings =
+    Http2Settings.default.copy(
+      maxHeaderListSize = config.maxResponseLineLength + config.maxHeadersLength // the request line is part of the headers
+    )
+
+  private[this] def buildPipeline(p: Promise[HttpClientSession])(s: String): LeafBuilder[ByteBuffer] = {
+    s match {
+      case H2 | H2_14 =>
+        logger.debug(s"Selected $s, resulted in H2 protocol.")
+        val f = new DefaultFlowStrategy(localSettings)
+        val handshaker = new ClientPriorKnowledgeHandshaker(localSettings, f, Execution.trampoline)
+        p.completeWith(handshaker.clientSession)
+        LeafBuilder(handshaker)
+
+      case _ =>
+        logger.debug(s"Selected $s, resulted in HTTP1 protocol.")
+        val clientStage = new Http1ClientStage(config)
+        p.success(clientStage)
+        LeafBuilder(clientStage)
+    }
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/Http2Client.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/Http2Client.scala
@@ -1,0 +1,18 @@
+package org.http4s.blaze.http.http2.client
+
+import org.http4s.blaze.http.{HttpClient, HttpClientConfig, HttpClientImpl}
+import org.http4s.blaze.http.http2.{Http2Settings, ImmutableHttp2Settings}
+
+
+object Http2Client {
+  private[this] val defaultSettings: ImmutableHttp2Settings =
+    Http2Settings.default.copy(initialWindowSize = 256*1024)
+
+  lazy val defaultH2Client: HttpClient = newH2Client()
+
+  private[blaze] def newH2Client(): HttpClient = {
+    val manager = Http2ClientSessionManagerImpl(HttpClientConfig.Default, defaultSettings)
+    new HttpClientImpl(manager)
+  }
+
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/Http2ClientSessionManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/Http2ClientSessionManagerImpl.scala
@@ -1,0 +1,135 @@
+package org.http4s.blaze.http.http2.client
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.channel.nio2.ClientChannelFactory
+import org.http4s.blaze.http.ALPNTokens._
+import org.http4s.blaze.http.HttpClientSession.Ready
+import org.http4s.blaze.http._
+import org.http4s.blaze.http.util.UrlTools.UrlComposition
+import org.http4s.blaze.http.http2._
+import org.http4s.blaze.http.util.UrlTools
+import org.http4s.blaze.pipeline.stages.SSLStage
+import org.http4s.blaze.pipeline.{Command, HeadStage, LeafBuilder}
+import org.http4s.blaze.util.Execution
+import org.log4s.getLogger
+
+import scala.collection.mutable
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
+
+object Http2ClientSessionManagerImpl {
+  def apply(
+    config: HttpClientConfig,
+    initialSettings: ImmutableHttp2Settings
+  ): Http2ClientSessionManagerImpl =
+    new Http2ClientSessionManagerImpl(
+      config = config,
+      initialSettings = initialSettings,
+      sessionCache = new mutable.HashMap[String, Future[Http2ClientSession]])
+}
+
+private[http] class Http2ClientSessionManagerImpl(
+    config: HttpClientConfig,
+    initialSettings: ImmutableHttp2Settings,
+    sessionCache: mutable.Map[String, Future[Http2ClientSession]])
+  extends ClientSessionManager {
+
+  private[this] val logger = getLogger
+  private[this] val factory = new ClientChannelFactory(group = config.channelGroup)
+
+  override def acquireSession(request: HttpRequest): Future[HttpClientSession] =
+    UrlTools.UrlComposition(request.url) match {
+      case Failure(t) =>
+        Future.failed(t)
+
+      case Success(composition) if !composition.scheme.equalsIgnoreCase("https") =>
+        val ex = new IllegalArgumentException(s"Only https URL's allowed")
+        Future.failed(ex)
+
+      case Success(composition) =>
+        sessionCache.synchronized {
+          sessionCache.get(composition.authority) match {
+            case Some(session) =>
+              session.flatMap { s =>
+                if (s.status == Ready) session
+                else makeAndStoreSession(composition)
+              }(Execution.trampoline).recoverWith {
+                case err =>
+                  logger.info(err)(s"Found bad session. Replacing.")
+                  makeAndStoreSession(composition)
+              }(Execution.trampoline)
+
+            case None =>
+              makeAndStoreSession(composition)
+          }
+        }
+    }
+
+
+  /** Close the `SessionManager` and free any resources */
+  override def close(): Future[Unit] = {
+    val sessions = sessionCache.synchronized {
+      val sessions = sessionCache.values.toList
+      sessionCache.clear()
+      sessions
+    }
+
+    sessions.foldLeft(Future.successful(())){ (acc, s) =>
+      // we turn it into a Future outside of the Future.flatMap
+      // to ensure that closeNow is called on each session
+      val f = s.flatMap(_.closeNow())(Execution.directec)
+      acc.flatMap(_ => f)(Execution.trampoline)
+    }
+  }
+
+  // No need to do anything on return since HTTP/2 sessions are shared, not taken.
+  override def returnSession(session: HttpClientSession): Unit = ()
+
+  // starts to acquire a new session and adds the attempt to the sessionCache
+  private[this] def makeAndStoreSession(url: UrlComposition): Future[Http2ClientSession] = {
+    logger.debug(s"Creating a new session for composition $url")
+
+    val fSession = acquireSession(url)
+    sessionCache.put(url.authority, fSession) match {
+      case Some(old) =>
+        old.onComplete {
+          case Success(session) => session.close(Duration.Inf)
+          case Failure(_) => // nop
+        }(Execution.directec)
+
+      case None => // nop
+    }
+    fSession
+  }
+
+  protected def acquireSession(url: UrlComposition): Future[Http2ClientSession] = {
+    logger.debug(s"Creating a new session for composition $url")
+    factory.connect(url.getAddress).flatMap(initialPipeline)(Execution.directec)
+  }
+
+  private[this] def initialPipeline(head: HeadStage[ByteBuffer]): Future[Http2ClientSession] = {
+    val p = Promise[Http2ClientSession]
+
+    def buildConnection(s: String): LeafBuilder[ByteBuffer] = {
+      if (s != H2 && s != H2_14)
+        logger.error(s"Failed to negotiate H2. Using H2 protocol anyway.")
+
+      val f = new DefaultFlowStrategy(initialSettings)
+      val handShaker = new ClientPriorKnowledgeHandshaker(initialSettings, f, Execution.trampoline)
+      p.completeWith(handShaker.clientSession)
+      LeafBuilder(handShaker)
+    }
+
+    val engine = config.getClientSslEngine()
+    engine.setUseClientMode(true)
+
+    LeafBuilder(new ALPNClientSelector(engine, Seq(H2, H2_14), H2, buildConnection))
+      .prepend(new SSLStage(engine))
+      .base(head)
+
+    head.sendInboundCommand(Command.Connected)
+    p.future
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/ClientSessionManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/ClientSessionManagerImplSpec.scala
@@ -53,7 +53,7 @@ class ClientSessionManagerImplSpec extends Specification {
       cache.get(connectionId).iterator.next must_== proxiedSession
     }
 
-    "dead HTTP/2 sesssions are removed" in {
+    "dead HTTP/2 sessions are removed" in {
       object bad extends Http2ClientSession {
         var closed = false
         override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???

--- a/http/src/test/scala/org/http4s/blaze/http/http2/client/Http2ClientSessionManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/client/Http2ClientSessionManagerImplSpec.scala
@@ -1,0 +1,101 @@
+package org.http4s.blaze.http.http2.client
+
+import org.http4s.blaze.http.HttpClientSession.{Closed, Ready, ReleaseableResponse, Status}
+import org.http4s.blaze.http.http2.Http2Settings
+import org.http4s.blaze.http.util.UrlTools.UrlComposition
+import org.http4s.blaze.http.{Http2ClientSession, _}
+import org.specs2.mutable.Specification
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
+
+class Http2ClientSessionManagerImplSpec extends Specification {
+  private val connectionId = ClientSessionManagerImpl.ConnectionId("https", "www.foo.com")
+
+  private val req = HttpRequest("GET", "https://www.foo.com/bar", 1, 1, Seq.empty, BodyReader.EmptyBodyReader)
+
+  private def cacheWithSession(session: Http2ClientSession): mutable.Map[String, Future[Http2ClientSession]] = {
+    val map = new mutable.HashMap[String, Future[Http2ClientSession]]()
+    map.put(connectionId.authority, Future.successful(session))
+
+    map
+  }
+
+  private def managerWithCache(cache: mutable.Map[String, Future[Http2ClientSession]]): Http2ClientSessionManagerImpl =
+    new Http2ClientSessionManagerImpl(HttpClientConfig.Default, Http2Settings.default, cache)
+
+  private def managerWithSession(session: Http2ClientSession): Http2ClientSessionManagerImpl =
+    managerWithCache(cacheWithSession(session))
+
+  "Http2ClientSessionManagerImpl" should {
+    "acquire an existing session from the pool" in {
+      val session = new Http2ClientSession {
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = ???
+        override def status: Status = Ready
+        override def quality: Double = 1.0
+        override def ping(): Future[Duration] = ???
+      }
+
+      val manager = managerWithSession(session)
+      manager.acquireSession(req).value must beSome(Success(session))
+    }
+
+    "get the same session from the pool so long as it's healthy" in {
+      val session = new Http2ClientSession {
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = ???
+        override def status: Status = Ready
+        override def quality: Double = 1.0
+        override def ping(): Future[Duration] = ???
+      }
+      val cache = cacheWithSession(session)
+      val manager = managerWithCache(cache)
+
+      val f1 = manager.acquireSession(req)
+      val f2 = manager.acquireSession(req)
+
+      f1.value must_== f2.value
+      f1.value must beSome(Success(session))
+    }
+
+    "dead HTTP/2 sessions are removed" in {
+      object bad extends Http2ClientSession {
+        var closed = false
+        override def dispatch(request: HttpRequest): Future[ReleaseableResponse] = ???
+        override def close(within: Duration): Future[Unit] = {
+          closed = true
+          Future.successful(())
+        }
+        override def ping(): Future[Duration] = ???
+        override def status: Status = Closed
+        override def quality: Double = 1.0
+      }
+
+      val cache = cacheWithSession(bad)
+      val markerEx = new Exception("marker")
+      val manager = new Http2ClientSessionManagerImpl(HttpClientConfig.Default, Http2Settings.default, cache) {
+        override protected def acquireSession(url: UrlComposition): Future[Http2ClientSession] =
+          Future.failed(markerEx)
+      }
+
+      // if we get the marker it's because we tried to make a new session
+      manager.acquireSession(req).value must beLike {
+        case Some(Failure(ex)) => ex must_== markerEx
+      }
+
+      bad.closed must beTrue
+    }
+
+    "reject http urls" in {
+      val manager = managerWithSession(null) // not not important
+      val fSession = manager.acquireSession(req.copy(url = "http://www.foo.com/bar"))
+      fSession.value must beLike {
+        case Some(Failure(ex: IllegalArgumentException)) => ok
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Finally, we have a HTTP/2 client. It still needs a battery of
end-to-end tests which are run against a local server.