### PR TITLE
Add the server side RequestParser

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/BodyWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/BodyWriter.scala
@@ -29,7 +29,7 @@ trait BodyWriter {
 
   /** Flush any bytes to the pipeline
     *
-    * This may be a NOOP depending on the nature of the[[BodyWriter]].
+    * This may be a no-op depending on the nature of the[[BodyWriter]].
     *
     * @return a `Future[Unit]` that resolves when any buffers have been flushed.
     */

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
@@ -12,7 +12,7 @@ import org.http4s.blaze.pipeline.{Command, TailStage}
 import org.http4s.blaze.util.{BufferTools, Execution}
 
 import scala.collection.immutable.VectorBuilder
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 private class ClientStage(request: HttpRequest) extends TailStage[StreamMessage] {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/RequestParser.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/RequestParser.scala
@@ -1,0 +1,80 @@
+package org.http4s.blaze.http.http2.server
+
+import org.http4s.blaze.http.http2.StageTools._
+import org.http4s.blaze.http.{BodyReader, HttpRequest, _}
+
+import scala.collection.mutable.ArrayBuffer
+
+/** Tool for turning a HEADERS frame into a request */
+private object RequestParser {
+  def makeRequest(hs: Headers, body: BodyReader): Either[String, HttpRequest] = {
+
+    val normalHeaders = new ArrayBuffer[(String, String)](math.max(0, hs.size - 3))
+    var method: String = null
+    var scheme: String = null
+    var path: String = null
+    var error: String = ""
+    var pseudoDone = false
+
+    hs.foreach {
+      case (k, v) if isPseudo(k) =>
+        if (pseudoDone) error += s"Pseudo header ($k) in invalid position. "
+        else k match {
+          case Method =>
+            if (method == null) method = v
+            else error += "Multiple ':method' headers defined. "
+
+          case Scheme =>
+            if (scheme == null) scheme = v
+            else error += "Multiple ':scheme' headers defined. "
+
+          case Path =>
+            if (path == null) {
+              if (v.isEmpty) error += "Received :path pseudo-header with empty value. "
+              path = v
+            }
+            else error += "Multiple ':path' headers defined. "
+
+          case Authority => // NOOP; TODO: maybe we should synthesize a Host header out of this?
+
+          case _ =>
+            // Endpoints MUST treat a request or response that contains
+            // undefined or invalid pseudo-header fields as malformed
+            // https://tools.ietf.org/html/rfc7540#section-8.1.2.1
+            error += s"Invalid pseudo header: $k. "
+        }
+
+      case h@(k, v) => // Non pseudo headers
+        pseudoDone = true
+        k match {
+          case Connection =>
+            error += s"HTTP/2.0 forbids connection specific headers: $h. "
+
+          case TE =>
+            if (!v.equalsIgnoreCase("trailers")) error += "HTTP/2.0 forbids TE header values other than 'trailers'. "
+          // ignore otherwise
+
+          case _ if !validHeaderName(k) =>
+            error += s"Invalid header key: $k. "
+
+          case header =>
+            normalHeaders += h
+        }
+    }
+
+    // All HTTP/2 requests MUST include exactly one valid value for the
+    // ":method", ":scheme", and ":path" pseudo-header fields, unless it is
+    // a CONNECT request (Section 8.3).  An HTTP request that omits
+    // mandatory pseudo-header fields is malformed (Section 8.1.2.6).
+    // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+    if (method == null || scheme == null || path == null) {
+      error += s"Invalid request: missing pseudo headers. Method: $method, Scheme: $scheme, path: $path. "
+    }
+
+    if (0 < error.length) Left(error)
+    else Right(HttpRequest(method, path, 2, 0, normalHeaders.result(), body))
+  }
+
+  private[this] def isPseudo(key: String): Boolean =
+    0 < key.length && key.charAt(0) == ':'
+}

--- a/http/src/main/scala/org/http4s/blaze/http/util/UrlTools.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/util/UrlTools.scala
@@ -40,11 +40,6 @@ private[blaze] object UrlTools {
     }
   }
 
-  private[this] def isPrefixedWithHTTP(string: String): Boolean = {
-    string.length >= 4 &&
-      (string.charAt(0) == 'h' || string.charAt(0) == 'H') &&
-      (string.charAt(1) == 't' || string.charAt(1) == 'T') &&
-      (string.charAt(2) == 't' || string.charAt(2) == 'T') &&
-      (string.charAt(3) == 'p' || string.charAt(3) == 'P')
-  }
+  private[this] def isPrefixedWithHTTP(string: String): Boolean =
+    string.regionMatches(true, 0, "http", 0, 4)
 }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/RequestParserSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/RequestParserSpec.scala
@@ -1,0 +1,99 @@
+package org.http4s.blaze.http.http2.server
+
+import org.http4s.blaze.http._
+import org.specs2.mutable.Specification
+
+class RequestParserSpec extends Specification {
+
+  "RequestParser" >> {
+    "prepares a valid incoming request" >> {
+      val hs = Seq(
+        ":method" -> "GET",
+        ":scheme" -> "https",
+        ":path" -> "/",
+        "other" -> "funny header"
+      )
+      RequestParser.makeRequest(hs, BodyReader.EmptyBodyReader) must beLike {
+        case Right(HttpRequest("GET", "/", 2, 0, headers, BodyReader.EmptyBodyReader)) =>
+          headers must_== Seq("other" -> "funny header")
+      }
+    }
+
+    "rejects invalid pseudo headers" >> {
+      val invalidHs = Seq(
+        Seq(), // empty
+        Seq( // missing :method pseudo header
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "other" -> "funny header"
+        ),
+        Seq( // multiple :method pseudo headers
+          ":method" -> "GET",
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "other" -> "funny header"
+        ),
+        Seq( // missing :scheme pseudo header
+          ":method" -> "GET",
+          ":path" -> "/",
+          "other" -> "funny header"
+        ),
+        Seq( // multiple :scheme pseudo headers
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "other" -> "funny header"
+        ),
+        Seq( // missing :path pseudo header
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          "other" -> "funny header"
+        ),
+        Seq( // multiple :path pseudo headers
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          ":path" -> "/",
+          "other" -> "funny header"
+        ),
+        Seq( // undefined pseudo header
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          ":undefined" -> "",
+          "other" -> "funny header"
+        ),
+        Seq( // pseudo header after normal headers
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          "other" -> "funny header",
+          ":path" -> "/"
+        ),
+        Seq( // illegal header name
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "illega l" -> "cant have spaces in the name"
+        ),
+        Seq( // cannot have Connection specific headers
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "connection" -> "sadface"
+        ),
+        Seq( // TE other than 'trailers'
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "te" -> "chunked"
+        )
+      )
+
+      forall(invalidHs) { hs =>
+        RequestParser.makeRequest(hs, BodyReader.EmptyBodyReader) must beLeft
+      }
+    }
+  }
+}


### PR DESCRIPTION
The RequestParser turns a sequence of pseudo-headers and a body into a
legit HttpRequest while rejecting malformed request preludes according
to the spec.

Also some smaller cleanups included.