### PR TITLE
Add the HTTP/2 AbstractBodyWriter

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriter.scala
@@ -1,0 +1,91 @@
+package org.http4s.blaze.http.http2.server
+
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamMessage}
+import org.http4s.blaze.http.{BodyWriter, Headers, InternalWriter}
+import org.http4s.blaze.util.BufferTools
+
+import scala.concurrent.Future
+
+private abstract class AbstractBodyWriter(private var hs: Headers) extends BodyWriter {
+  final override type Finished = Unit
+
+  // must be protected by synchronized on `this`
+  private[this] var closed = false
+
+  // must only be called while synchronized on `this`
+  private[this] def takeHeaders(): Headers = {
+    val taken = hs
+    hs = null
+    taken
+  }
+
+  protected def flushMessage(msg: StreamMessage): Future[Unit]
+
+  protected def flushMessage(msg: Seq[StreamMessage]): Future[Unit]
+
+  final override def write(buffer: ByteBuffer): Future[Unit] = {
+    var hsToFlush: Headers = null
+    val wasClosed = this.synchronized {
+      if (closed) true
+      else {
+        hsToFlush = takeHeaders()
+        false
+      }
+    }
+
+    if (wasClosed) InternalWriter.closedChannelException
+    else if (hsToFlush != null) {
+      val hs = HeadersFrame(Priority.NoPriority, false, hsToFlush)
+      if (!buffer.hasRemaining) flushMessage(hs)
+      else {
+        val bodyFrame = DataFrame(false, buffer)
+        flushMessage(hs :: bodyFrame :: Nil)
+      }
+    }
+    else if (!buffer.hasRemaining) InternalWriter.cachedSuccess
+    else {
+      val bodyFrame = DataFrame(false, buffer)
+      flushMessage(bodyFrame)
+    }
+  }
+
+  final override def flush(): Future[Unit] = {
+    var hsToFlush: Headers = null
+    val wasClosed = this.synchronized {
+      if (closed) true
+      else {
+        hsToFlush = takeHeaders()
+        false
+      }
+    }
+    if (wasClosed) InternalWriter.closedChannelException
+    else if (hsToFlush == null) InternalWriter.cachedSuccess
+    else {
+      // need to flush the headers
+      val hs = HeadersFrame(Priority.NoPriority, false, hsToFlush)
+      flushMessage(hs)
+    }
+  }
+
+  final override def close(): Future[Finished] = {
+    var hsToFlush: Headers = null
+    val wasClosed = this.synchronized {
+      if (closed) true
+      else {
+        hsToFlush = takeHeaders()
+        closed = true
+        false
+      }
+    }
+    if (wasClosed) InternalWriter.closedChannelException
+    else if (hsToFlush != null) {
+      val frame = HeadersFrame(Priority.NoPriority, true, hsToFlush)
+      flushMessage(frame)
+    } else {
+      val frame = DataFrame(true, BufferTools.emptyBuffer)
+      flushMessage(frame)
+    }
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriterSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriterSpec.scala
@@ -1,0 +1,127 @@
+package org.http4s.blaze.http.http2.server
+
+import java.io.IOException
+import java.nio.ByteBuffer
+
+import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamMessage}
+import org.http4s.blaze.util.BufferTools
+import org.specs2.mutable.Specification
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+class AbstractBodyWriterSpec extends Specification {
+
+  private val hs = Seq("one" -> "two")
+
+  private def hsFrame(eos: Boolean): HeadersFrame = HeadersFrame(Priority.NoPriority, eos, hs)
+
+  private def data(size: Int): ByteBuffer = BufferTools.allocate(size)
+
+  private def dataFrame(eos: Boolean, size: Int): DataFrame = DataFrame(eos, data(size))
+
+  private def checkSuccess(t: Future[Unit]): Boolean = t.value match {
+    case Some(Success(())) => true
+    case other => sys.error(s"Unexpected value: $other")
+  }
+
+  private def checkIOException(t: Future[Unit]): Boolean = t.value match {
+    case Some(Failure(_: IOException)) => true // nop
+    case other => sys.error(s"Unexpected value: $other")
+  }
+
+  private class WriterImpl extends AbstractBodyWriter(hs) {
+
+    var flushed: Option[Seq[StreamMessage]] = None
+
+    override protected def flushMessage(msg: StreamMessage): Future[Unit] = flushMessage(msg::Nil)
+
+    override protected def flushMessage(msg: Seq[StreamMessage]): Future[Unit] = {
+      assert(flushed.isEmpty)
+      flushed = Some(msg)
+      Future.successful(())
+    }
+  }
+
+  "AbstractBodyWriter" >> {
+    "flush" >> {
+      "Flushes headers if they haven't been written" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.flush())
+        writer.flushed must_== Some(Seq(hsFrame(false)))
+      }
+
+      "Flushes nothing if the headers are already gone" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.flush())
+        writer.flushed must_== Some(Seq(hsFrame(false)))
+        writer.flushed = None
+
+        // try again
+        checkSuccess(writer.flush())
+        writer.flushed must beNone
+      }
+
+      "Flush results in failure of already closed" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.close())
+        checkIOException(writer.flush())
+      }
+    }
+
+    "write" >> {
+      "Flushes headers and data if they haven't been written" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.write(data(1)))
+        writer.flushed must_== Some(Seq(hsFrame(false), dataFrame(false, 1)))
+      }
+
+      "Flushes data if the headers are already gone" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.flush())
+        writer.flushed must beSome
+        writer.flushed = None
+
+        checkSuccess(writer.write(data(1)))
+        writer.flushed must_== Some(Seq(dataFrame(false, 1)))
+      }
+
+      "Flush results in failure of already closed" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.close())
+        writer.flushed must beSome
+        writer.flushed = None
+
+        checkIOException(writer.write(data(1)))
+      }
+    }
+
+    "close" >> {
+      "Flushes headers if they haven't been written" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.close())
+        writer.flushed must_== Some(Seq(hsFrame(true)))
+      }
+
+      "Flushes empty data if the headers are already gone" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.flush())
+        writer.flushed must_== Some(Seq(hsFrame(false)))
+        writer.flushed = None
+
+        checkSuccess(writer.close())
+        writer.flushed must_== Some(Seq(dataFrame(true, 0)))
+      }
+
+      "results in failure of already closed" >> {
+        val writer = new WriterImpl
+        checkSuccess(writer.close())
+        writer.flushed must_== Some(Seq(hsFrame(true)))
+        writer.flushed = None
+
+        checkIOException(writer.close())
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
It serves as the `BodyWriter` implementation for HTTP/2 server responses.