### PR TITLE
Add the HTTP/2 ServerStage

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/InternalWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/InternalWriter.scala
@@ -1,10 +1,11 @@
 package org.http4s.blaze.http
 
-import java.io.IOException
+import org.http4s.blaze.pipeline.Command
+
 import scala.concurrent.Future
 
 private object InternalWriter {
-  val cachedSuccess = Future.successful(())
-  def closedChannelException = Future.failed(new IOException("Channel closed"))
-  val bufferLimit = 32*1024
+  val CachedSuccess = Future.successful(())
+  val ClosedChannelException = Future.failed(Command.EOF)
+  val BufferLimit = 32*1024
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StageTools.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StageTools.scala
@@ -1,8 +1,11 @@
 package org.http4s.blaze.http.http2
 
+import java.util.Locale
+
 import org.http4s.blaze.http.util.HeaderNames
 
 import scala.annotation.tailrec
+import scala.collection.generic.Growable
 import scala.collection.BitSet
 
 
@@ -19,6 +22,19 @@ private object StageTools {
   val Connection = HeaderNames.Connection
   val ContentLength = HeaderNames.ContentLength
 
+  /** Copy HTTP headers from `source` to dest
+    *
+    * The keys of `source` are converted to lower case to conform with the HTTP/2 spec.
+    * https://tools.ietf.org/html/rfc7540#section-8.1.2
+    */
+  def copyHeaders(source: Iterable[(String, String)], dest: Growable[(String, String)]): Unit = {
+    source.foreach { case p @ (k, v) =>
+      val lowerKey = k.toLowerCase(Locale.ENGLISH)
+      if (lowerKey eq k) dest += p // don't need to make a new Tuple2
+      else dest += lowerKey -> v
+    }
+  }
+
   /** Check of the header name is a valid http2 header name.
     * Pseudo headers are considered invalid and should be screened before hand.
     */
@@ -33,15 +49,15 @@ private object StageTools {
     s > 0 && go(0)
   }
 
-  /* HTTP2 Spec, 8.1.2 HTTP Header Fields  : http://http2.github.io/http2-spec/index.html#HttpHeaders
+  /* HTTP2 Spec, 8.1.2 HTTP Header Fields
 
-    "Just as in HTTP/1.x, header field names are strings of ASCII characters that are compared
+     Just as in HTTP/1.x, header field names are strings of ASCII characters that are compared
      in a case-insensitive fashion. However, header field names MUST be converted to lowercase
      prior to their encoding in HTTP/2. A request or response containing uppercase header
-     field names MUST be treated as malformed (Section 8.1.2.6). "
+     field names MUST be treated as malformed (Section 8.1.2.6).
+     https://tools.ietf.org/html/rfc7540#section-8.1.2
 
-
-    HTTP/1.1 def: https://tools.ietf.org/html/rfc7230
+     HTTP/1.1 def: https://tools.ietf.org/html/rfc7230
      header-field   = field-name ":" OWS field-value OWS
      field-name     = token
      token          = 1*tchar
@@ -51,6 +67,5 @@ private object StageTools {
                     ; any VCHAR, except delimiters
 
    */
-
-  private val validChars = BitSet((('0' to '9') ++ ('a' to 'z') ++ "!#$%&'*+-.^_`|~") map (_.toInt):_*)
+  private val validChars = BitSet((('0' to '9') ++ ('a' to 'z') ++ "!#$%&'*+-.^_`|~").map(_.toInt):_*)
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
@@ -186,12 +186,7 @@ private object ClientStage {
       hs += StageTools.Authority -> breakdown.authority
       hs += StageTools.Path -> breakdown.fullPath
 
-      // Header keys need to be lower cased
-      request.headers.foreach { case p @ (k, v) =>
-        val lowerKey = k.toLowerCase(Locale.ENGLISH)
-        if (lowerKey eq k) hs += p
-        else hs += lowerKey -> v
-      }
+      StageTools.copyHeaders(request.headers, hs)
 
       hs.result()
     }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriter.scala
@@ -35,7 +35,7 @@ private abstract class AbstractBodyWriter(private var hs: Headers) extends BodyW
       }
     }
 
-    if (wasClosed) InternalWriter.closedChannelException
+    if (wasClosed) InternalWriter.ClosedChannelException
     else if (hsToFlush != null) {
       val hs = HeadersFrame(Priority.NoPriority, false, hsToFlush)
       if (!buffer.hasRemaining) flushMessage(hs)
@@ -44,7 +44,7 @@ private abstract class AbstractBodyWriter(private var hs: Headers) extends BodyW
         flushMessage(hs :: bodyFrame :: Nil)
       }
     }
-    else if (!buffer.hasRemaining) InternalWriter.cachedSuccess
+    else if (!buffer.hasRemaining) InternalWriter.CachedSuccess
     else {
       val bodyFrame = DataFrame(false, buffer)
       flushMessage(bodyFrame)
@@ -60,8 +60,8 @@ private abstract class AbstractBodyWriter(private var hs: Headers) extends BodyW
         false
       }
     }
-    if (wasClosed) InternalWriter.closedChannelException
-    else if (hsToFlush == null) InternalWriter.cachedSuccess
+    if (wasClosed) InternalWriter.ClosedChannelException
+    else if (hsToFlush == null) InternalWriter.CachedSuccess
     else {
       // need to flush the headers
       val hs = HeadersFrame(Priority.NoPriority, false, hsToFlush)
@@ -79,7 +79,7 @@ private abstract class AbstractBodyWriter(private var hs: Headers) extends BodyW
         false
       }
     }
-    if (wasClosed) InternalWriter.closedChannelException
+    if (wasClosed) InternalWriter.ClosedChannelException
     else if (hsToFlush != null) {
       val frame = HeadersFrame(Priority.NoPriority, true, hsToFlush)
       flushMessage(frame)

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerStage.scala
@@ -1,0 +1,148 @@
+package org.http4s.blaze.http.http2.server
+
+import java.nio.ByteBuffer
+import java.util.Locale
+
+import org.http4s.blaze.http._
+import org.http4s.blaze.http.http2.Http2Exception._
+import org.http4s.blaze.http.http2.StageTools._
+import org.http4s.blaze.http.http2.{HeadersFrame, StageTools, StreamMessage}
+import org.http4s.blaze.http.util.ServiceTimeoutFilter
+import org.http4s.blaze.pipeline.{TailStage, Command => Cmd}
+import org.http4s.blaze.util.{BufferTools, Execution}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+/** Basic implementation of a http2 stream [[TailStage]] */
+private[http] class ServerStage(
+  streamId: Int,
+  service: HttpService,
+  config: HttpServerStageConfig
+) extends TailStage[StreamMessage] {
+
+  private implicit def _ec = Execution.trampoline // for all the onComplete calls
+
+  private val timeoutService = ServiceTimeoutFilter(config.serviceTimeout)(service)
+
+  override def name = s"Http2StreamStage($streamId)"
+
+  override protected def stageStartup(): Unit = {
+    super.stageStartup()
+    startRequest()
+  }
+
+  private def shutdownWithCommand(cmd: Cmd.OutboundCommand): Unit = {
+    stageShutdown()
+    sendOutboundCommand(cmd)
+  }
+
+  private def startRequest(): Unit = {
+    // The prelude should already be available (or we wouldn't have a stream id)
+    // so adding a timeout is unnecessary.
+    channelRead().onComplete  {
+      case Success(HeadersFrame(_, endStream, hs)) =>
+        if (endStream) checkAndRunRequest(hs, BodyReader.EmptyBodyReader)
+        else getBodyReader(hs)
+
+      case Success(frame) =>
+        val e = PROTOCOL_ERROR.goaway(
+          s"Stream $streamId received invalid frame: ${frame.getClass.getSimpleName}")
+        shutdownWithCommand(Cmd.Error(e))
+
+        // TODO: what about a 408 response for a timeout?
+      case Failure(Cmd.EOF) => shutdownWithCommand(Cmd.Disconnect)
+
+      case Failure(t) =>
+        logger.error(t)("Unknown error in startRequest")
+        val e = INTERNAL_ERROR.rst(streamId, s"Unknown error")
+        shutdownWithCommand(Cmd.Error(e))
+    }(Execution.directec)
+  }
+
+  private[this] def getBodyReader(hs: Headers): Unit = {
+    val length: Option[Try[Long]] = hs.collectFirst {
+      case (ContentLength, v) =>
+        try Success(java.lang.Long.valueOf(v))
+        catch { case t: NumberFormatException =>
+           Failure(PROTOCOL_ERROR.rst(streamId, s"Invalid content-length: $v."))
+        }
+    }
+
+    length match {
+      case Some(Success(len)) => checkAndRunRequest(hs, new BodyReaderImpl(len))
+      case Some(Failure(error)) => shutdownWithCommand(Cmd.Error(error))
+      case None => checkAndRunRequest(hs, new BodyReaderImpl(-1))
+    }
+  }
+
+  private[this] def checkAndRunRequest(hs: Headers, bodyReader: BodyReader): Unit = {
+    RequestParser.makeRequest(hs, bodyReader) match {
+      case Right(request) =>
+        timeoutService(request).onComplete(renderResponse(request.method, _))(config.serviceExecutor)
+
+      case Left(errMsg) =>
+        shutdownWithCommand(Cmd.Error(PROTOCOL_ERROR.rst(streamId, errMsg)))
+    }
+  }
+
+  private[this] def renderResponse(method: String, response: Try[RouteAction]): Unit = response match {
+    case Success(builder) =>
+      builder.handle(getWriter(method, _))
+        .onComplete(onComplete)(Execution.directec)
+
+    case Failure(t) => shutdownWithCommand(Cmd.Error(t))
+  }
+
+  private[this] def getWriter(method: String, prelude: HttpResponsePrelude): BodyWriter = {
+    val sizeHint = prelude.headers match {case b: IndexedSeq[_] => b.size + 1; case _ => 16 }
+    val hs = new ArrayBuffer[(String, String)](sizeHint)
+    hs += ((Status, Integer.toString(prelude.code)))
+
+    StageTools.copyHeaders(prelude.headers, hs)
+    // HEAD requests must not have a response body, so we ensure
+    // that by using the `NoopWriter`, which only flushes the headers
+    // and fails with an EOF for the `flush` and `write` operations.
+    if (method == "HEAD") new NoopWriter(hs)
+    else new StandardWriter(hs)
+  }
+
+  ///////// BodyWriter's /////////////////////////////
+
+  private class StandardWriter(hs: Headers) extends AbstractBodyWriter(hs) {
+    override protected def flushMessage(msg: StreamMessage): Future[Unit] =
+      channelWrite(msg)
+
+    override protected def flushMessage(msg: Seq[StreamMessage]): Future[Unit] =
+      channelWrite(msg)
+  }
+
+  private def onComplete(result: Try[_]): Unit = result match {
+    case Success(_)       => shutdownWithCommand(Cmd.Disconnect)
+    case Failure(Cmd.EOF) => stageShutdown()
+    case Failure(t)       => shutdownWithCommand(Cmd.Error(t))
+  }
+
+  private class NoopWriter(headers: Headers) extends BodyWriter {
+    override type Finished = Unit
+
+    private val underlying = new StandardWriter(headers)
+
+    override def write(buffer: ByteBuffer): Future[Unit] = {
+      underlying.close().flatMap { _ =>
+        sendOutboundCommand(Cmd.Disconnect)
+        InternalWriter.ClosedChannelException
+      }
+    }
+
+    override def flush(): Future[Unit] = write(BufferTools.emptyBuffer)
+
+    override def close(): Future[Unit] = underlying.close()
+  }
+
+  private class BodyReaderImpl(length: Long) extends AbstractBodyReader(streamId, length) {
+    override protected def channelRead(): Future[StreamMessage] = ServerStage.this.channelRead()
+    override protected def failed(ex: Throwable): Unit = sendOutboundCommand(Cmd.Error(ex))
+  }
+}

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriterSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriterSpec.scala
@@ -4,6 +4,7 @@ import java.io.IOException
 import java.nio.ByteBuffer
 
 import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamMessage}
+import org.http4s.blaze.pipeline.Command
 import org.http4s.blaze.util.BufferTools
 import org.specs2.mutable.Specification
 
@@ -26,7 +27,7 @@ class AbstractBodyWriterSpec extends Specification {
   }
 
   private def checkIOException(t: Future[Unit]): Boolean = t.value match {
-    case Some(Failure(_: IOException)) => true // nop
+    case Some(Failure(Command.EOF)) => true // nop
     case other => sys.error(s"Unexpected value: $other")
   }
 

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/ServerStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/ServerStageSpec.scala
@@ -1,0 +1,172 @@
+package org.http4s.blaze.http.http2.server
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+import org.http4s.blaze.http.http2._
+import org.http4s.blaze.http.http2.mocks.MockHeadStage
+import org.http4s.blaze.http._
+import org.http4s.blaze.pipeline.{Command, LeafBuilder}
+import org.http4s.blaze.util.{BufferTools, Execution}
+import org.specs2.mutable.Specification
+
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class ServerStageSpec extends Specification {
+
+  private implicit def ex = Execution.trampoline
+
+  private val goodHeaders = Seq(
+    ":method" -> "GET",
+    ":scheme" -> "https",
+    ":path" -> "/",
+    "other" -> "funny header"
+  )
+
+  private class Ctx {
+
+    lazy val service: HttpService = { _ =>
+      Future.successful(RouteAction.Ok("foo"))
+    }
+
+    lazy val config = HttpServerStageConfig()
+
+    lazy val head = new MockHeadStage[StreamMessage]
+
+    lazy val stage: ServerStage = new ServerStage(1, service, config)
+
+    def connect(): Unit = {
+      LeafBuilder(stage).base(head)
+      head.sendInboundCommand(Command.Connected)
+    }
+  }
+
+  "ServerStage" >> {
+
+    "fails to start with a non-headers frame" >> {
+      val ctx = new Ctx
+      import ctx._
+
+      connect()
+      head.reads.dequeue().success(DataFrame(false, BufferTools.emptyBuffer))
+      head.error must beLike {
+        case Some(ex: Http2SessionException) => ex.code must_== Http2Exception.PROTOCOL_ERROR.code
+      }
+    }
+
+    "generates an empty body if the first frame has EOS" >> {
+      val ctx = new Ctx {
+        var hadBody: Option[Boolean] = None
+        override lazy val service: HttpService = { req =>
+          hadBody = Some(!req.body.isExhausted)
+          Future.successful(RouteAction.Ok("cool"))
+        }
+      }
+      import ctx._
+
+      connect()
+      head.reads.dequeue().success(HeadersFrame(Priority.NoPriority, true, goodHeaders))
+      hadBody must beSome(false)
+    }
+
+    "generates a body" >> {
+      val ctx = new Ctx {
+        val serviceReads = new mutable.Queue[ByteBuffer]
+        override lazy val service: HttpService = { req =>
+          for {
+            b1 <- req.body()
+            b2 <- req.body()
+            b3 <- req.body()
+          } yield {
+            serviceReads += b1
+            serviceReads += b2
+            serviceReads += b3
+            RouteAction.Ok("cool")
+          }
+        }
+      }
+      import ctx._
+
+      connect()
+      head.reads.dequeue().success(HeadersFrame(Priority.NoPriority, false, goodHeaders))
+      head.reads.dequeue().success(DataFrame(false, BufferTools.allocate(1)))
+      head.reads.dequeue().success(DataFrame(true, BufferTools.allocate(2)))
+
+      serviceReads.toList must_== List(BufferTools.allocate(1), BufferTools.allocate(2), BufferTools.emptyBuffer)
+    }
+
+    "The service can write the body" >> {
+      val ctx = new Ctx
+      import ctx._
+
+      connect()
+      head.reads.dequeue().success(HeadersFrame(Priority.NoPriority, true, goodHeaders))
+      val (HeadersFrame(_, false, hs), p) = head.writes.dequeue()
+      val hsMap = hs.toMap
+      hsMap(":status") must_== "200"
+      hsMap("content-length") must_== "3"
+      p.success(())
+
+      val (DataFrame(false, data), p2) = head.writes.dequeue()
+      data must_== StandardCharsets.UTF_8.encode("foo")
+    }
+
+    "finishing the action disconnects the stage" >> {
+      val ctx = new Ctx
+      import ctx._
+
+      connect()
+      head.reads.dequeue().success(HeadersFrame(Priority.NoPriority, true, goodHeaders))
+      val (HeadersFrame(_, false, _), p1) = head.writes.dequeue()
+      p1.success(())
+
+      val (DataFrame(false, _), p2) = head.writes.dequeue()
+      p2.success(())
+
+      val (DataFrame(true, data), p3) = head.writes.dequeue()
+      p3.success(())
+
+      data.remaining must_== 0
+      head.disconnected must beTrue
+    }
+
+    "failing the action disconnects with an error" >> {
+      val ex = new Exception("sadface")
+      val ctx = new Ctx {
+        override lazy val service: HttpService = { _ =>
+          Future.failed(ex)
+        }
+      }
+      import ctx._
+
+      connect()
+      head.reads.dequeue().success(HeadersFrame(Priority.NoPriority, true, goodHeaders))
+
+      head.error must beSome(ex)
+    }
+
+    "head requests get a noop writer" >> {
+      val ctx = new Ctx
+      import ctx._
+
+      val headHeaders = Seq(
+        ":method" -> "HEAD",
+        ":scheme" -> "https",
+        ":path" -> "/",
+        "other" -> "funny header"
+      )
+
+      connect()
+      head.reads.dequeue().success(HeadersFrame(Priority.NoPriority, true, headHeaders))
+      val (HeadersFrame(_, true, hs), p) = head.writes.dequeue()
+      val hsMap = hs.toMap
+      hsMap(":status") must_== "200"
+      hsMap("content-length") must_== "3"
+      p.success(())
+
+      head.disconnected must beTrue
+    }
+  }
+
+}


### PR DESCRIPTION
It drives the dispatch of individual stream requests and is a
one-time use abstraction: one per stream.