### PR TITLE
Cleanup the Http2ClientExample and add some docs

### DIFF
--- a/examples/src/main/scala/org/http4s/blaze/examples/http2/H2ClientExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/http2/H2ClientExample.scala
@@ -2,66 +2,56 @@ package org.http4s.blaze.examples.http2
 
 import java.nio.charset.StandardCharsets
 
-import org.http4s.blaze.http.HttpClient
 import org.http4s.blaze.http.http2.client.Http2Client
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
+/** Examples which calls the Twitter or Google home pages using HTTP/2
+  *
+  * @note the Jetty ALPN boot library must have been loaded in order for
+  *       ALPN negotiation to happen. See the Jetty docs at
+  *       https://www.eclipse.org/jetty/documentation/9.3.x/alpn-chapter.html
+  *       for more information.
+  */
+object H2ClientTwitterExample extends H2ClientExample("https://twitter.com/", 20, 30.seconds)
 
-abstract class H2ClientExample(count: Int, timeout: Duration) {
+object H2ClientGoogleExample extends H2ClientExample("https://www.google.com/", 20, 30.seconds)
+
+abstract class H2ClientExample(url: String, count: Int, timeout: Duration) {
 
   protected implicit val ec = scala.concurrent.ExecutionContext.global
 
-  lazy val h2Clients: Array[HttpClient] = Array.tabulate(3){_ => Http2Client.newH2Client() }
+  private[this] def doCall(tag: Int): Future[Int] = doCallString(tag).map(_.length)
 
-  def doCall(tag: Int): Future[Int]
+  private[this] def doCallString(tag: Int): Future[String] = {
+    Http2Client.defaultH2Client.GET("https://www.google.com/") { resp =>
+      resp.body.accumulate().map { bytes =>
+        println(s"Finished response $tag of bytes ${bytes.remaining}: ${resp.headers}")
+        StandardCharsets.UTF_8.decode(bytes).toString
+      }
+    }
+  }
 
   def main(args: Array[String]): Unit = {
-    println("Hello, world!")
+    println(s"${getClass.getSimpleName} performing $count requests")
 
-    Await.result(Future.sequence((0 until h2Clients.length).map(doCall)), 5.seconds)
+    Await.result(doCall(0), 5.seconds)
 
-    def fresps(i: Int) = (h2Clients.length until i).map { i =>
+    // call the specified number of times
+    def repeatCall(i: Int): Seq[Future[(Int, Int)]] = (0 until i).map { i =>
       doCall(i).map(i -> _)
     }
 
-    Await.result(Future.sequence(fresps(count / 5)), timeout)
+    Await.result(Future.sequence(repeatCall(count / 5)), timeout)
     val start = System.currentTimeMillis
-    val resps = Await.result(Future.sequence(fresps(count)), timeout)
+    val resps = Await.result(Future.sequence(repeatCall(count)), timeout)
     val duration = System.currentTimeMillis - start
 
-    val chars = resps.foldLeft(0){ case (acc, (i, len)) =>
+    val length = resps.foldLeft(0){ case (acc, (i, len)) =>
       acc + len
     }
 
-    println(s"The total body length of ${resps.length} messages: $chars. Took $duration millis")
-  }
-}
-
-object H2GoogleExample extends H2ClientExample(20, 30.seconds) {
-  override def doCall(tag: Int): Future[Int] = callGoogle(tag).map(_.length)
-
-  private[this] def callGoogle(tag: Int): Future[String] = {
-    Http2Client.defaultH2Client.GET("https://www.google.com/") { resp =>
-      resp.body.accumulate().map { bytes =>
-        println(s"Finished response $tag")
-        StandardCharsets.UTF_8.decode(bytes).toString
-      }
-    }
-  }
-}
-
-object H2TwitterExample extends H2ClientExample(20, 30.seconds) {
-  override def doCall(tag: Int): Future[Int] = callTwitter(tag).map(_.length)
-
-  private[this] def callTwitter(tag: Int): Future[String] = {
-    Http2Client.defaultH2Client.GET("https://twitter.com/") { resp =>
-      resp.body.accumulate().map { bytes =>
-
-        println(s"Finished response $tag of size ${bytes.remaining()}: ${resp.headers}")
-        StandardCharsets.UTF_8.decode(bytes).toString
-      }
-    }
+    println(s"The total body length of ${resps.length} messages: $length. Took $duration millis")
   }
 }

--- a/examples/src/main/scala/org/http4s/blaze/examples/http2/Http2ServerExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/http2/Http2ServerExample.scala
@@ -11,6 +11,16 @@ import org.http4s.blaze.http.http2.server.ServerSelector
 import org.http4s.blaze.pipeline.TrunkBuilder
 import org.http4s.blaze.pipeline.stages.SSLStage
 
+/** Basic HTTP/2 server example
+  *
+  * The server is capable of serving traffic over both HTTP/1.x and HTTP/2
+  * using TLS.
+  *
+  * @note the Jetty ALPN boot library must have been loaded in order for
+  *       ALPN negotiation to happen. See the Jetty docs at
+  *       https://www.eclipse.org/jetty/documentation/9.3.x/alpn-chapter.html
+  *       for more information.
+  */
 class Http2ServerExample(port: Int) {
   private val sslContext = ExampleKeystore.sslContext()
 

--- a/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
@@ -9,7 +9,17 @@ import org.http4s.blaze.util.Execution
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-/** Post routing response generator */
+/** Response generator for HTTP servers
+  *
+  * The route action can be thought of as a more complex version of the lambda
+  * `(HttpResponsePrelude => Writer) => Future[Writer#Finished]`
+  *
+  * with the key difference being the addition of the type parameter that makes
+  * the type of the generic, or more importantly, the `Writer#Finished` type
+  * member generic. By doing so, the only way to satisfy the return value is to
+  * call the `Writer`s `close()` method which has the return type
+  * `Future[Writer#Finished]`, ensuring that the writer is closed.
+  */
 trait RouteAction {
   /** Generate a HTTP response using the passed continuation
     *

--- a/http/src/main/scala/org/http4s/blaze/http/package.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/package.scala
@@ -7,6 +7,16 @@ package object http {
   type Url = String
   type Method = String
 
-  // The basic type that represents a HTTP service
+  /** The basic type that represents a HTTP service
+    *
+    * {{{
+    *   val service: HttpService = { req =>
+    *     Future.success(RouteAction.Ok("Hello, world!"))
+    *   }
+    * }}}
+    *
+    * @note When the `Future` returned by the `RouteAction` resolves, server
+    * implementations are free to forcibly close the request body.
+    */
   type HttpService = HttpRequest => Future[RouteAction]
 }


### PR DESCRIPTION
Clean up duplication in the HTTP/2 client examples and add notes about the need for the Jetty ALPN library. Also added some docs to some of the HTTP/2 primitives.