### PR TITLE
Bump version to 0.14.0-M1 for release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import BlazePlugin._
 organization in ThisBuild := "org.http4s"
 
 lazy val commonSettings = Seq(
-  version := "0.14.0-SNAPSHOT",
+  version := "0.14.0-M1",
   description := "NIO Framework for Scala",
   crossScalaVersions := Seq("2.11.11", scalaVersion.value),
   scalacOptions in (Compile, doc) ++= Seq("-no-link-warnings") // Suppresses problems with Scaladoc @throws links


### PR DESCRIPTION
The first milestone release of the 0.14.0 series, now with a new HTTP/2 server **_and_** client implementation!