### PR TITLE
SelectorLoop cleanup

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -11,24 +11,36 @@ import java.nio.channels._
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.{Executor, RejectedExecutionException}
 
 import org.log4s.getLogger
 
+import scala.concurrent.ExecutionContext
 
-final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extends Thread(id) { thisLoop =>
+/** A special thread that listens for events on the provided selector
+  *
+  * @param id The name of this `SelectorLoop`
+  * @param selector the `Selector` to listen on
+  * @param bufferSize size of the scratch buffer instantiated for this thread
+  */
+final class SelectorLoop(
+  id: String,
+  selector: Selector,
+  bufferSize: Int
+) extends Thread(id) with Executor with ExecutionContext {
+
+  // a node in the task queue with a reference to the next task
+  private[this] class Node(val runnable: Runnable) extends AtomicReference[Node]
 
   private[this] val logger = getLogger
 
-  // a node in the task queue with a reference to the next task
-  private class Node(val runnable: Runnable) extends AtomicReference[Node]
-
   // a reference to the latest added Node
-  private val queueHead = new AtomicReference[Node](null)
+  private[this] val queueHead = new AtomicReference[Node](null)
   // a reference to the first added Node
-  private val queueTail = new AtomicReference[Node](null)
+  private[this] val queueTail = new AtomicReference[Node](null)
 
-  @volatile private var _isClosed = false
+  @volatile
+  private[this] var _isClosed = false
 
   /** Signal to the [[SelectorLoop]] that it should close */
   def close(): Unit = {
@@ -38,20 +50,35 @@ final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extend
     ()
   }
 
+  /** Schedule the provided `Runnable` for execution, potentially running it now
+    *
+    * The provided task may be executed *now* if the calling thread is `this`
+    * `SelectorLoop`, otherwise it is added to the task queue to be executed by
+    * the `SelectorLoop` thread later.
+    */
   @inline
-  final def executeTask(r: Runnable): Unit =  {
-    if (Thread.currentThread() == thisLoop) r.run()
-    else enqueueTask(r)
+  def executeTask(runnable: Runnable): Unit =  {
+    if (Thread.currentThread() != this) enqueueTask(runnable)
+    else {
+      try runnable.run()
+      catch { case NonFatal(t) => reportFailure(t) }
+    }
   }
 
-  @deprecated("Renamed to enqueueTask", "0.12.8")
-  def enqueTask(r: Runnable): Unit =
-    enqueueTask(r)
-
-  def enqueueTask(r: Runnable): Unit = {
+  /** Schedule to provided `Runnable` for execution later
+    *
+    * The task will be added to the end of the queue of tasks scheduled
+    * for execution regardless of where this method is called.
+    *
+    * @see `executeTask` for a method that will execute the task now if
+    *     the calling thread is `this` `SelectorLoop`, or schedule it for
+    *     later otherwise.
+    */
+  def enqueueTask(runnable: Runnable): Unit = {
+    // TODO: there is a risk of scheduling the task but the thread being closed
     if (_isClosed) throw new RejectedExecutionException("This SelectorLoop is closed.")
 
-    val node = new Node(r)
+    val node = new Node(runnable)
     val head = queueHead.getAndSet(node)
     if (head eq null) {
       queueTail.set(node)
@@ -60,27 +87,75 @@ final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extend
     } else head.lazySet(node)
   }
 
-  def initChannel(builder: BufferPipelineBuilder, ch: SelectableChannel, mkStage: SelectionKey => NIO1HeadStage): Unit = {
+  override def execute(runnable: Runnable): Unit = enqueueTask(runnable)
+
+  override def reportFailure(cause: Throwable): Unit = {
+    logger.info(cause)(s"Exception executing task in selector look $id")
+  }
+
+  /** Initialize a new `Selectable` channel
+    *
+    * The `SelectableChannel` is added to the selector loop and
+    * the pipeline is constructed using the resultant `SelectionKey`
+    */
+  def initChannel(
+    builder: BufferPipelineBuilder,
+    ch: SelectableChannel,
+    mkStage: SelectionKey => NIO1HeadStage
+  ): Unit = {
     enqueueTask( new Runnable {
       def run(): Unit = {
+        ch.configureBlocking(false)
+        val key = ch.register(selector, 0)
         try {
-          ch.configureBlocking(false)
-          val key = ch.register(selector, 0)
-
           val head = mkStage(key)
           key.attach(head)
-
           // construct the pipeline
           builder(NIO1Connection(ch)).base(head)
-
           head.inboundCommand(Command.Connected)
           logger.debug("Started channel.")
-        } catch { case e: Throwable => logger.error(e)("Caught error during channel init.") }
+        } catch {
+          case NonFatal(e) =>
+            logger.error(e)("Caught error during channel init.")
+            key.attach(null)
+            key.cancel()
+            ch.close()
+        }
       }
     })
   }
 
-  private def runTasks(): Unit = {
+  // Main thread method. The loop will break if the Selector loop is closed
+  override def run(): Unit = {
+    // The scratch buffer is a direct buffer as this will often be used for I/O
+    val scratch = ByteBuffer.allocateDirect(bufferSize)
+
+    try while(!_isClosed) {
+      // Run any pending tasks. These may set interest ops, just compute something, etc.
+      runTasks()
+
+      // Block here until some IO event happens or someone adds a task to run and wakes the loop
+      if (0 < selector.select()) {
+        // We have some new IO operations waiting for us. Process them
+        val it = selector.selectedKeys().iterator()
+        processKeys(scratch, it)
+      }
+
+    } catch {
+      case e: ClosedSelectorException =>
+        _isClosed = true
+        logger.error(e)("Selector unexpectedly closed")
+
+      case e: Throwable =>
+        logger.error(e)("Unhandled exception in selector loop")
+        _isClosed = true
+    }
+
+    // If we've made it to here, we've exited the run loop and we need to shut down
+    killSelector()
+  }
+
+  private[this] def runTasks(): Unit = {
     @tailrec def spin(n: Node): Node = {
       val next = n.get()
       if (next ne null) next
@@ -107,79 +182,42 @@ final class SelectorLoop(id: String, selector: Selector, bufferSize: Int) extend
     }
   }
 
-  // Main thread method. The loop will break if the Selector loop is closed
-  override def run(): Unit = {
-    // The scratch buffer is a direct buffer as this will often be used for I/O
-    val scratch = ByteBuffer.allocateDirect(bufferSize)
+  private[this] def processKeys(scratch: ByteBuffer, it: java.util.Iterator[SelectionKey]): Unit = {
+    while(it.hasNext) {
+      val k = it.next()
+      it.remove()
 
-    try while(!_isClosed) {
-      // Run any pending tasks. These may set interest ops, just compute something, etc.
-      runTasks()
-
-    // Block here until some IO event happens or someone adds a task to run and wakes the loop
-      if (selector.select() > 0) {
-        // We have some new IO operations waiting for us. Process them
-        val it = selector.selectedKeys().iterator()
-
-        while(it.hasNext) {
-          val k = it.next()
-          it.remove()
+      try if (k.isValid) {
+        val head = k.attachment.asInstanceOf[NIO1HeadStage]
+        if (head != null) {
+          head.opsReady(scratch)
+        } else {
+          // Null head. Must be disconnected
+          k.cancel()
+          logger.error("Illegal state: selector key had null attachment.")
+        }
+      } catch {
+        case t: Throwable =>
+          logger.error(t) {
+            if (t.isInstanceOf[IOException]) "IOException while performing channel operations. Closing channel."
+            else "Error performing channel operations. Closing channel."
+          }
 
           try {
-            if (k.isValid) {
-              val head = k.attachment().asInstanceOf[NIO1HeadStage]
-
-              if (head != null) {
-                val readyOps: Int = k.readyOps()
-
-                if ((readyOps & SelectionKey.OP_READ) != 0) head.readReady(scratch)
-                if ((readyOps & SelectionKey.OP_WRITE) != 0) head.writeReady(scratch)
-              }
-              else {   // Null head. Must be disconnected
-                k.cancel()
-                logger.warn("Selector key had null attachment. Why is the key still in the ops?")
-              }
-
-            }
+            val head = k.attachment.asInstanceOf[NIO1HeadStage]
+            head.closeWithError(t)
           } catch {
-            case e: CancelledKeyException => /* NOOP */
-            case t: Throwable =>
-              logger.error(t) {
-                if (t.isInstanceOf[IOException]) "IOException while performing channel operations. Closing channel."
-                else "Error performing channel operations. Closing channel."
-              }
-
-              try {
-                val head = k.attachment().asInstanceOf[NIO1HeadStage]
-                head.closeWithError(t)
-              } catch {
-                case NonFatal(_) => /* NOOP */
-                case t: Throwable => logger.error(t)("Fatal error shutting down pipeline")
-              }
-              k.attach(null)
-              k.cancel()
+            case NonFatal(_) => /* NOOP */
+            case t: Throwable => logger.error(t)("Fatal error shutting down pipeline")
           }
-        }
+          k.attach(null)
+          k.cancel()
       }
-
-    } catch {
-      case e: IOException => logger.error(e)("IOException in SelectorLoop while acquiring selector")
-      case e: ClosedSelectorException =>
-        _isClosed = true
-        logger.error(e)("Selector unexpectedly closed")
-
-      case e: Throwable =>
-        logger.error(e)("Unhandled exception in selector loop")
-        _isClosed = true
     }
-
-    // If we've made it to here, we've exited the run loop and we need to shut down
-    killSelector()
   }
 
-  private def killSelector(): Unit = {
+  private[this] def killSelector(): Unit = {
     import scala.collection.JavaConverters._
-
     try {
       selector.keys().asScala.foreach { k =>
         try {

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -129,7 +129,7 @@ final class SelectorLoop(
 
       // Block here until some IO event happens or someone adds
       // a task to run and wakes the loop
-      if (0 < selector.select()) {
+      if (selector.select() > 0) {
         // We have some new IO operations waiting for us. Process them
         val it = selector.selectedKeys().iterator()
         processKeys(scratch, it)

--- a/core/src/main/scala/org/http4s/blaze/util/MPSCQueue.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/MPSCQueue.scala
@@ -1,0 +1,5 @@
+package org.http4s.blaze.util
+
+class MPSCQueue {
+
+}

--- a/core/src/main/scala/org/http4s/blaze/util/MPSCQueue.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/MPSCQueue.scala
@@ -1,5 +1,0 @@
-package org.http4s.blaze.util
-
-class MPSCQueue {
-
-}

--- a/core/src/main/scala/org/http4s/blaze/util/TaskQueue.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TaskQueue.scala
@@ -1,0 +1,133 @@
+package org.http4s.blaze.util
+
+import java.util.concurrent.atomic.AtomicReference
+
+import org.log4s.getLogger
+
+import scala.annotation.tailrec
+import scala.util.control.{ControlThrowable, NonFatal}
+
+/** Multi-producer single-consumer queue implementation */
+private[blaze] final class TaskQueue {
+  import TaskQueue._
+
+  // A reference to the head of the queue.
+  private[this] val queueHead = new AtomicReference[Node](null)
+
+  // The tail of the queue. Elements added to the queue take this
+  // position and 'link' the previous tail to themselves. If no
+  // previous tail existed, it is placed in the `queueHead` pointer.
+  private[this] val queueTail = new AtomicReference[Node](null)
+
+  /** Whether the queue has been closed */
+  def isClosed: Boolean = queueTail.get eq ClosedNode
+
+  /** Whether the queue has tasks pending execution */
+  def needsExecution: Boolean = queueHead.get ne null
+
+  /** Close the MPSC queue, executing all pending tasks */
+  def close(): Unit = {
+    val tail = queueTail.getAndSet(ClosedNode)
+    if (tail ne null) {
+      // The queue wasn't empty, so we link the
+      // tail and execute the remaining tasks
+      tail.lazySet(ClosedNode)
+      executeTasks()
+    }
+  }
+
+  /** Attempt to enqueue the task for execution
+    *
+    * This method is safe to call from multiple threads
+    */
+  def enqueueTask(runnable: Runnable): Result = {
+    val node = new Node(runnable)
+
+    @tailrec
+    def loop(): Result = {
+      val tail = queueTail.get
+      if (tail == ClosedNode) Closed // closed
+      else if (!queueTail.compareAndSet(tail, node)) loop() // lost the race
+      else if (tail != null) {
+          // link the head -> node
+          tail.lazySet(node)
+          Enqueued
+      } else {
+        // this was the first element in the queue
+        queueHead.set(node)
+        FirstEnqueued
+      }
+    }
+
+    loop()
+  }
+
+  /** Execute all tasks in the queue
+    *
+    * All tasks, including those that are scheduled during the invocation of
+    * this method, either by this a task that is executed or those scheduled
+    * from another thread, will be executed in the calling thread.
+    */
+  def executeTasks(): Unit = {
+    // spin while we wait for the tail of the node to resolve
+    @tailrec def spin(node: Node): Node = {
+      val next = node.get
+      if (next ne null) next
+      else spin(node)
+    }
+
+    @tailrec
+    def go(node: Node): Unit = {
+      if (node ne ClosedNode) {
+        try node.runnable.run()
+        catch {
+          case t @ (NonFatal(_) | _: ControlThrowable) =>
+            logger.error(t)("Caught exception in queued task")
+        }
+        val next = node.get
+        if (next eq null) {
+          // If we are not the last cell, we will spin until the cons resolves and continue
+          if (!queueTail.compareAndSet(node, null)) {
+            go(spin(node))
+          }
+          //else () // Finished the last node. All done.
+        }
+        else go(next)
+      }
+    }
+
+    val t = queueHead.getAndSet(null)
+    if (t ne null) {
+      go(t)
+    }
+  }
+}
+
+private[blaze] object TaskQueue {
+  private val logger = getLogger
+
+  // a node in the task queue with a reference to the next task
+  private class Node(val runnable: Runnable) extends AtomicReference[Node]
+
+  /** Result of offering a task to the queue */
+  sealed trait Result extends Product with Serializable
+
+  /** The element was enqueued */
+  case object Enqueued extends Result
+
+  /** The element was enqueued and was the first element in the queue */
+  case object FirstEnqueued extends Result
+
+  /** Failed to enqueue the element because the queue is closed */
+  case object Closed extends Result
+
+  // Marker node that when found in tail position says that
+  // the queue is closed.
+  private val ClosedNode = new Node(new Runnable {
+    def run(): Unit = {
+      val ex = bug("Illegal state reached! TaskQueue found executing " +
+        "a marker node. Please report as a bug.")
+      logger.error(ex)("Unexpected state")
+    }
+  })
+}

--- a/core/src/test/scala/org/http4s/blaze/util/TaskQueueSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/util/TaskQueueSpec.scala
@@ -1,0 +1,118 @@
+package org.http4s.blaze.util
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.specs2.mutable.Specification
+
+import scala.util.control.ControlThrowable
+
+class TaskQueueSpec extends Specification {
+
+  "TaskQueue" >> {
+    "offer a task" >> {
+      val q = new TaskQueue
+      q.needsExecution must beFalse
+      q.isClosed must beFalse
+
+      q.enqueueTask(new Runnable { def run(): Unit = () }) must_== TaskQueue.FirstEnqueued
+      q.enqueueTask(new Runnable { def run(): Unit = () }) must_== TaskQueue.Enqueued
+      q.needsExecution must beTrue
+    }
+
+    "reject a tasks when closed" >> {
+      val q = new TaskQueue
+      q.needsExecution must beFalse
+      q.isClosed must beFalse
+
+      // the closing latch will be await on by the main thread before testing the behavior
+      val closingLatch = new CountDownLatch(1)
+      q.enqueueTask(new Runnable { def run(): Unit = closingLatch.countDown() }) must_== TaskQueue.FirstEnqueued
+
+      // this latch makes the closing thread block *in* the close call, giving us a chance to test
+      val blockCloseLatch = new CountDownLatch(1)
+      q.enqueueTask(new Runnable { def run(): Unit = blockCloseLatch.await() }) must_== TaskQueue.Enqueued
+
+      // The closing thread will close shop, first ticking the `closingLatch`, then waiting for this thread
+      val closingThead = new Thread(new Runnable { def run(): Unit = q.close() })
+      closingThead.start()
+
+      // once this method call returns we know the closing thread is in the `close()` call
+      closingLatch.await(30, TimeUnit.SECONDS) must beTrue
+      q.isClosed must beTrue
+      closingThead.isAlive must beTrue
+
+      q.enqueueTask(new Runnable { def run(): Unit = () }) must_== TaskQueue.Closed
+      blockCloseLatch.countDown()
+      closingThead.join(30000) // wait at most 30 seconds
+      closingThead.isAlive must beFalse
+
+      q.isClosed must beTrue
+      q.enqueueTask(new Runnable { def run(): Unit = () }) must_== TaskQueue.Closed
+    }
+
+    "execute tasks added by this thread while executing" >> {
+      val q = new TaskQueue
+      val count = new AtomicInteger(0)
+
+      class SelfEqueuer(remaining: Int) extends Runnable {
+        override def run(): Unit = {
+          if (0 < remaining) {
+            count.incrementAndGet()
+            q.enqueueTask(new SelfEqueuer(remaining - 1))
+          }
+        }
+      }
+
+      q.enqueueTask(new SelfEqueuer(10))
+      q.executeTasks()
+      count.get must_== 10
+    }
+
+    "execute tasks added by another thread while executing" >> {
+      val q = new TaskQueue
+
+      // let the main thread know we're mid-execution
+      val executingLatch = new CountDownLatch(1)
+      q.enqueueTask(new Runnable { def run(): Unit = executingLatch.countDown() })
+
+      // Wait for the main thread to unblock
+      val sleepLatch = new CountDownLatch(1)
+      q.enqueueTask(new Runnable { def run(): Unit = sleepLatch.await() })
+
+      val t = new Thread(new Runnable { def run(): Unit = q.executeTasks() })
+      t.start()
+
+      // wait for the worker thread to enter the work loop
+      executingLatch.await(30, TimeUnit.SECONDS) must beTrue
+
+      // Add a task from this thread
+      val counter = new AtomicInteger(0)
+      q.enqueueTask(new Runnable {
+        def run(): Unit = {
+          counter.incrementAndGet()
+          ()
+        }
+      }) must_== TaskQueue.Enqueued
+
+      sleepLatch.countDown()
+      t.join(30000) // 30 seconds max
+      counter.get must_== 1
+    }
+
+    "`NonFatal` and `ControlThrowable`s are caught by the execute loop" >> {
+      val q = new TaskQueue
+      q.enqueueTask(new Runnable {
+        def run(): Unit = throw new Exception("sadface")
+      })
+
+      q.enqueueTask(new Runnable {
+        def run(): Unit = throw new ControlThrowable {}
+      })
+
+      q.executeTasks()
+      q.needsExecution must beFalse
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #164 

Cleanup the `SelectorLoop`. While doing so a task leak was discovered where a `Runnable` could be added to the `SelectorLoop`s queue of tasks to execute, but would never be executed if the selector got closed at a slightly unlucky time.