### PR TITLE
Rename StreamMessage to StreamFrame

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http2/Connection.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/Connection.scala
@@ -53,7 +53,7 @@ private trait Connection {
     * not guaranteed to succeed.
     */
   // TODO: right now this only benefits the client. We need to get the push-promise support for the server side
-  def newOutboundStream(): HeadStage[StreamMessage]
+  def newOutboundStream(): HeadStage[StreamFrame]
 
   /** Hook into the shutdown events of the connection */
   def onClose: Future[Unit]

--- a/http/src/main/scala/org/http4s/blaze/http/http2/ConnectionImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/ConnectionImpl.scala
@@ -23,7 +23,7 @@ private final class ConnectionImpl(
   val localSettings: Http2Settings,
   val remoteSettings: MutableHttp2Settings,
   flowStrategy: FlowStrategy,
-  inboundStreamBuilder: Option[Int => LeafBuilder[StreamMessage]],
+  inboundStreamBuilder: Option[Int => LeafBuilder[StreamFrame]],
   parentExecutor: ExecutionContext
 ) extends SessionCore with Connection {
 
@@ -144,7 +144,7 @@ private final class ConnectionImpl(
     onClose
   }
 
-  override def newOutboundStream(): HeadStage[StreamMessage] =
+  override def newOutboundStream(): HeadStage[StreamFrame] =
     streamManager.newOutboundStream()
 
   override def onClose: Future[Unit] = closedPromise.future

--- a/http/src/main/scala/org/http4s/blaze/http/http2/OutboundStreamStateImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/OutboundStreamStateImpl.scala
@@ -33,7 +33,7 @@ private abstract class OutboundStreamStateImpl(session: SessionCore)
   }
 
   // We need to establish whether the stream has been initialized yet and try to acquire a new ID if not
-  final override protected def invokeStreamWrite(msg: StreamMessage, p: Promise[Unit]): Unit = {
+  final override protected def invokeStreamWrite(msg: StreamFrame, p: Promise[Unit]): Unit = {
     if (initialized) {
       super.invokeStreamWrite(msg, p)
     } else if (session.state.closing) {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamFrame.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamFrame.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 /** Types that will be sent down to the Nodes of the Http2 session */
 
-sealed trait StreamMessage {
+sealed trait StreamFrame {
   def endStream: Boolean
   def flowBytes: Int
 }
@@ -16,7 +16,7 @@ sealed trait StreamMessage {
   *             The `ByteBuffer` indexes are considered owned by this DataFrame, but its
   *             data must not be modified.
   */
-case class DataFrame(endStream: Boolean, data: ByteBuffer) extends StreamMessage {
+case class DataFrame(endStream: Boolean, data: ByteBuffer) extends StreamFrame {
   def flowBytes = data.remaining()
 }
 
@@ -28,6 +28,6 @@ case class DataFrame(endStream: Boolean, data: ByteBuffer) extends StreamMessage
   */
 case class HeadersFrame(priority: Priority,
                        endStream: Boolean,
-                         headers: Seq[(String,String)]) extends StreamMessage {
+                         headers: Seq[(String,String)]) extends StreamFrame {
   override def flowBytes: Int = 0
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{Future, Promise}
 
 private final class StreamManagerImpl(
   session: SessionCore,
-  inboundStreamBuilder: Option[Int => LeafBuilder[StreamMessage]]
+  inboundStreamBuilder: Option[Int => LeafBuilder[StreamFrame]]
 ) extends StreamManager {
   private[this] val logger = org.log4s.getLogger
   private[this] val streams = new HashMap[Int, StreamState]

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamState.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamState.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import org.http4s.blaze.pipeline.HeadStage
 
-private trait StreamState extends HeadStage[StreamMessage] with WriteInterest {
+private trait StreamState extends HeadStage[StreamFrame] with WriteInterest {
 
   /** Stream ID associated with this stream */
   def streamId: Int

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable.VectorBuilder
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
-private class ClientStage(request: HttpRequest) extends TailStage[StreamMessage] {
+private class ClientStage(request: HttpRequest) extends TailStage[StreamFrame] {
   import ClientStage._
 
   private[this] val lock: Object = this

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyReader.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyReader.scala
@@ -3,7 +3,7 @@ package org.http4s.blaze.http.http2.server
 import java.nio.ByteBuffer
 
 import org.http4s.blaze.http.BodyReader
-import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, StreamMessage}
+import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, StreamFrame}
 import org.http4s.blaze.http.http2.Http2Exception._
 import org.http4s.blaze.util.{BufferTools, Execution}
 import org.log4s.getLogger
@@ -25,7 +25,7 @@ private abstract class AbstractBodyReader(streamId: Int, length: Long) extends B
 
   private[this] val logger = getLogger
 
-  protected def channelRead(): Future[StreamMessage]
+  protected def channelRead(): Future[StreamFrame]
 
   protected def failed(ex: Throwable): Unit
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriter.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.http2.server
 
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamMessage}
+import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamFrame}
 import org.http4s.blaze.http.{BodyWriter, Headers, InternalWriter}
 import org.http4s.blaze.util.BufferTools
 
@@ -21,9 +21,9 @@ private abstract class AbstractBodyWriter(private var hs: Headers) extends BodyW
     taken
   }
 
-  protected def flushMessage(msg: StreamMessage): Future[Unit]
+  protected def flushMessage(msg: StreamFrame): Future[Unit]
 
-  protected def flushMessage(msg: Seq[StreamMessage]): Future[Unit]
+  protected def flushMessage(msg: Seq[StreamFrame]): Future[Unit]
 
   final override def write(buffer: ByteBuffer): Future[Unit] = {
     var hsToFlush: Headers = null

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerPriorKnowledgeHandshaker.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerPriorKnowledgeHandshaker.scala
@@ -14,7 +14,7 @@ import scala.util.Failure
 private[http] class ServerPriorKnowledgeHandshaker(
     localSettings: ImmutableHttp2Settings,
     flowStrategy: FlowStrategy,
-    nodeBuilder: Int => LeafBuilder[StreamMessage])
+    nodeBuilder: Int => LeafBuilder[StreamFrame])
   extends PriorKnowledgeHandshaker[Unit](localSettings) {
 
   override protected def stageStartup(): Unit = synchronized {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerSelector.scala
@@ -6,7 +6,7 @@ import javax.net.ssl.SSLEngine
 import org.http4s.blaze.http._
 import org.http4s.blaze.http.ALPNTokens._
 import org.http4s.blaze.http.http1.server.Http1ServerStage
-import org.http4s.blaze.http.http2.{DefaultFlowStrategy, Http2Settings, StreamMessage}
+import org.http4s.blaze.http.http2.{DefaultFlowStrategy, Http2Settings, StreamFrame}
 import org.http4s.blaze.pipeline.{LeafBuilder, TailStage}
 import org.log4s.getLogger
 
@@ -38,7 +38,7 @@ object ServerSelector {
   private def http2Stage(service: HttpService, config: HttpServerStageConfig): TailStage[ByteBuffer] = {
     logger.debug("Selected HTTP2")
 
-    def newNode(streamId: Int): LeafBuilder[StreamMessage] =
+    def newNode(streamId: Int): LeafBuilder[StreamFrame] =
       LeafBuilder(new ServerStage(streamId, service, config))
 
     val localSettings =

--- a/http/src/test/scala/org/http4s/blaze/http/endtoend/scaffolds/Http2ServerScaffold.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/endtoend/scaffolds/Http2ServerScaffold.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.endtoend.scaffolds
 
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.http2.{DefaultFlowStrategy, Http2Settings, StreamMessage}
+import org.http4s.blaze.http.http2.{DefaultFlowStrategy, Http2Settings, StreamFrame}
 import org.http4s.blaze.http.http2.server.{ServerStage, ServerPriorKnowledgeHandshaker}
 import org.http4s.blaze.http.{HttpServerStageConfig, _}
 import org.http4s.blaze.pipeline.{LeafBuilder, TailStage}
@@ -14,7 +14,7 @@ import org.http4s.blaze.pipeline.{LeafBuilder, TailStage}
 class Http2ServerScaffold(service: HttpService) extends ServerScaffold {
 
   private def http2Stage(service: HttpService, config: HttpServerStageConfig): TailStage[ByteBuffer] = {
-    def newNode(streamId: Int): LeafBuilder[StreamMessage] =
+    def newNode(streamId: Int): LeafBuilder[StreamFrame] =
       LeafBuilder(new ServerStage(streamId, service, config))
 
     val localSettings = Http2Settings.default.copy(

--- a/http/src/test/scala/org/http4s/blaze/http/http2/ConnectionImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/ConnectionImplSpec.scala
@@ -32,7 +32,7 @@ class ConnectionImplSpec extends Specification {
 
     lazy val flowStrategy = new DefaultFlowStrategy(localSettings)
 
-    lazy val streamBuilder: Option[Int => LeafBuilder[StreamMessage]] = None
+    lazy val streamBuilder: Option[Int => LeafBuilder[StreamFrame]] = None
 
     lazy val connection = new ConnectionImpl(
       tailStage = tailStage,
@@ -85,7 +85,7 @@ class ConnectionImplSpec extends Specification {
 
         // need to use the stream before it actually counts
         val stream = connection.newOutboundStream()
-        val tail = new BasicTail[StreamMessage]("tail")
+        val tail = new BasicTail[StreamFrame]("tail")
         LeafBuilder(tail).base(stream)
         tail.channelWrite(HeadersFrame(Priority.NoPriority, true, Seq.empty))
 
@@ -176,7 +176,7 @@ class ConnectionImplSpec extends Specification {
         import ctx._
 
         val stage = connection.newOutboundStream()
-        val basicStage = new BasicTail[StreamMessage]("")
+        val basicStage = new BasicTail[StreamFrame]("")
         LeafBuilder(basicStage).base(stage)
 
         val w1 = basicStage.channelWrite(HeadersFrame(Priority.NoPriority, endStream = true, Seq.empty))
@@ -198,7 +198,7 @@ class ConnectionImplSpec extends Specification {
         import ctx._
 
         val stage = connection.newOutboundStream()
-        val basicStage = new BasicTail[StreamMessage]("")
+        val basicStage = new BasicTail[StreamFrame]("")
         LeafBuilder(basicStage).base(stage)
 
         val w1 = basicStage.channelWrite(HeadersFrame(Priority.NoPriority, endStream = false, Seq.empty))
@@ -220,7 +220,7 @@ class ConnectionImplSpec extends Specification {
         connection.invokeDrain(4.seconds)
 
         val stage = connection.newOutboundStream()
-        val basicStage = new BasicTail[StreamMessage]("")
+        val basicStage = new BasicTail[StreamFrame]("")
         LeafBuilder(basicStage).base(stage)
         val f = basicStage.channelWrite(HeadersFrame(Priority.NoPriority, true, Seq.empty))
         f.value must beLike {
@@ -246,7 +246,7 @@ class ConnectionImplSpec extends Specification {
         import ctx._
 
         val stage = connection.newOutboundStream()
-        val basicStage = new BasicTail[StreamMessage]("")
+        val basicStage = new BasicTail[StreamFrame]("")
         LeafBuilder(basicStage).base(stage)
 
         val w1 = basicStage.channelWrite(HeadersFrame(Priority.NoPriority, endStream = false, Seq.empty))
@@ -267,7 +267,7 @@ class ConnectionImplSpec extends Specification {
         connection.invokeDrain(4.seconds)
 
         val stage = connection.newOutboundStream()
-        val basicStage = new BasicTail[StreamMessage]("")
+        val basicStage = new BasicTail[StreamFrame]("")
         LeafBuilder(basicStage).base(stage)
         val f = basicStage.channelWrite(HeadersFrame(Priority.NoPriority, true, Seq.empty))
         f.value must beLike {

--- a/http/src/test/scala/org/http4s/blaze/http/http2/SessionFrameListenerSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/SessionFrameListenerSpec.scala
@@ -19,7 +19,7 @@ class SessionFrameListenerSpec extends Specification {
         true, // discard overflow headers
         localSettings.headerTableSize)
 
-    lazy val newInboundStream: Option[Int => LeafBuilder[StreamMessage]] = None
+    lazy val newInboundStream: Option[Int => LeafBuilder[StreamFrame]] = None
 
     lazy val frameListener: SessionFrameListener =
       new SessionFrameListener(this, isClient, headerDecoder)
@@ -50,7 +50,7 @@ class SessionFrameListenerSpec extends Specification {
       }
 
       "initiate a new stream for idle inbound stream (server)" >> {
-        val head = new BasicTail[StreamMessage]("")
+        val head = new BasicTail[StreamFrame]("")
         val tools = new MockTools(isClient = false) {
           override lazy val newInboundStream = Some { _: Int => LeafBuilder(head) }
         }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/StreamManagerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/StreamManagerImplSpec.scala
@@ -16,7 +16,7 @@ class StreamManagerImplSpec extends Specification {
 
     var connects: Int = 0
 
-    lazy val tail = new TailStage[StreamMessage] {
+    lazy val tail = new TailStage[StreamFrame] {
       override def name: String = "name"
       override def inboundCommand(cmd: Command.InboundCommand): Unit = {
         if (cmd == Command.Connected) { connects += 1 }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/client/ClientStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/client/ClientStageSpec.scala
@@ -41,7 +41,7 @@ class ClientStageSpec extends Specification {
 
     "Mark the first HEADERS frame as EOS if there isn't a body" >> {
       val cs = new ClientStage(request)
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -53,7 +53,7 @@ class ClientStageSpec extends Specification {
     "Not mark the first HEADERS frame EOS if there is a body" >> {
       val body = BodyReader.singleBuffer(ByteBuffer.allocate(1))
       val cs = new ClientStage(request.copy(body = body))
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -66,7 +66,7 @@ class ClientStageSpec extends Specification {
       val d = ByteBuffer.allocate(1)
       val body = BodyReader.singleBuffer(d)
       val cs = new ClientStage(request.copy(body = body))
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -79,7 +79,7 @@ class ClientStageSpec extends Specification {
 
     "Response will have an empty body if the first inbound frame is marked EOS" >> {
       val cs = new ClientStage(request)
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -94,7 +94,7 @@ class ClientStageSpec extends Specification {
 
     "Responses with a body can have the body available through the reader" >> {
       val cs = new ClientStage(request)
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -119,7 +119,7 @@ class ClientStageSpec extends Specification {
 
     "Releasing the response will send a disconnect message" >> {
       val cs = new ClientStage(request)
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -134,7 +134,7 @@ class ClientStageSpec extends Specification {
 
     "Failure of writing the request prelude results in a disconnect" >> {
       val cs = new ClientStage(request)
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)
@@ -149,7 +149,7 @@ class ClientStageSpec extends Specification {
 
     "Failure to read the response results in a disconnect" >> {
       val cs = new ClientStage(request)
-      val head = new MockHeadStage[StreamMessage]
+      val head = new MockHeadStage[StreamFrame]
       LeafBuilder(cs).base(head)
 
       head.sendInboundCommand(Command.Connected)

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyReaderSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyReaderSpec.scala
@@ -28,12 +28,12 @@ class AbstractBodyReaderSpec extends Specification {
     b
   }
 
-  private class TestBodyReader(length: Long, data: Seq[StreamMessage]) extends AbstractBodyReader(1, length) {
+  private class TestBodyReader(length: Long, data: Seq[StreamFrame]) extends AbstractBodyReader(1, length) {
     var failedReason: Option[Throwable] = None
-    val reads = new mutable.Queue[StreamMessage]
+    val reads = new mutable.Queue[StreamFrame]
     reads ++= data
 
-    override protected def channelRead(): Future[StreamMessage] =
+    override protected def channelRead(): Future[StreamFrame] =
       Future.successful(reads.dequeue())
 
     override protected def failed(ex: Throwable): Unit = {

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriterSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/AbstractBodyWriterSpec.scala
@@ -3,7 +3,7 @@ package org.http4s.blaze.http.http2.server
 import java.io.IOException
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamMessage}
+import org.http4s.blaze.http.http2.{DataFrame, HeadersFrame, Priority, StreamFrame}
 import org.http4s.blaze.pipeline.Command
 import org.http4s.blaze.util.BufferTools
 import org.specs2.mutable.Specification
@@ -33,11 +33,11 @@ class AbstractBodyWriterSpec extends Specification {
 
   private class WriterImpl extends AbstractBodyWriter(hs) {
 
-    var flushed: Option[Seq[StreamMessage]] = None
+    var flushed: Option[Seq[StreamFrame]] = None
 
-    override protected def flushMessage(msg: StreamMessage): Future[Unit] = flushMessage(msg::Nil)
+    override protected def flushMessage(msg: StreamFrame): Future[Unit] = flushMessage(msg::Nil)
 
-    override protected def flushMessage(msg: Seq[StreamMessage]): Future[Unit] = {
+    override protected def flushMessage(msg: Seq[StreamFrame]): Future[Unit] = {
       assert(flushed.isEmpty)
       flushed = Some(msg)
       Future.successful(())

--- a/http/src/test/scala/org/http4s/blaze/http/http2/server/ServerStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/server/ServerStageSpec.scala
@@ -32,7 +32,7 @@ class ServerStageSpec extends Specification {
 
     lazy val config = HttpServerStageConfig()
 
-    lazy val head = new MockHeadStage[StreamMessage]
+    lazy val head = new MockHeadStage[StreamFrame]
 
     lazy val stage: ServerStage = new ServerStage(1, service, config)
 


### PR DESCRIPTION
This naming is more consistent with what it represents and the
subclasses DataFrame and HeadersFrame.