### PR TITLE
Start opening up the HTTP/2 types for http4s proper consumption

### DIFF
--- a/examples/src/main/scala/org/http4s/blaze/examples/ExampleService.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/ExampleService.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicReference
 
 import org.http4s.blaze.channel.ServerChannel
-import org.http4s.blaze.http.util.HeaderNames
 import org.http4s.blaze.http._
 import org.http4s.blaze.pipeline.stages.monitors.IntervalConnectionMonitor
 import org.http4s.blaze.util.{BufferTools, Execution}

--- a/http/src/main/scala/org/http4s/blaze/http/HeaderNames.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/HeaderNames.scala
@@ -1,12 +1,15 @@
-package org.http4s.blaze.http.util
+package org.http4s.blaze.http
 
 /**
-  * Incomplete collection of header names, all lower case.
+  * Incomplete collection of header names, all lower case for
+  * easy compatibility with HTTP/2.
   */
-private[blaze] object HeaderNames {
+object HeaderNames {
   val Connection = "connection"
   val ContentLength = "content-length"
   val ContentType = "content-type"
   val Date = "date"
+  val TE = "te"
   val TransferEncoding = "transfer-encoding"
+
 }

--- a/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
@@ -3,7 +3,6 @@ package org.http4s.blaze.http
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
-import org.http4s.blaze.http.util.HeaderNames
 import org.http4s.blaze.util.Execution
 
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerStage.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.http1.server
 
 import java.nio.ByteBuffer
 
-import org.http4s.blaze.http.util.{HeaderNames, ServiceTimeoutFilter}
+import org.http4s.blaze.http.util.ServiceTimeoutFilter
 import org.http4s.blaze.http.{HttpRequest, HttpServerStageConfig, RouteAction, _}
 import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.pipeline.{Command => Cmd, _}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/DefaultFlowStrategy.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/DefaultFlowStrategy.scala
@@ -2,7 +2,7 @@ package org.http4s.blaze.http.http2
 
 import org.http4s.blaze.http.http2.FlowStrategy.Increment
 
-private[http] class DefaultFlowStrategy(localSettings: Http2Settings) extends FlowStrategy {
+final class DefaultFlowStrategy(localSettings: Http2Settings) extends FlowStrategy {
 
   override def checkSession(session: SessionFlowControl): Int = {
     check(

--- a/http/src/main/scala/org/http4s/blaze/http/http2/PriorKnowledgeHandshaker.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/PriorKnowledgeHandshaker.scala
@@ -8,6 +8,7 @@ import org.http4s.blaze.util.{BufferTools, Execution}
 
 import scala.concurrent.Future
 
+/** Base type for performing the HTTP/2 prior knowledge handshake */
 abstract class PriorKnowledgeHandshaker[T](localSettings: ImmutableHttp2Settings) extends TailStage[ByteBuffer] {
 
   final protected implicit def ec = Execution.trampoline

--- a/http/src/main/scala/org/http4s/blaze/http/http2/PseudoHeaders.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/PseudoHeaders.scala
@@ -1,0 +1,13 @@
+package org.http4s.blaze.http.http2
+
+/** HTTP/2 pseudo headers */
+object PseudoHeaders {
+  // Request pseudo headers
+  val Method = ":method"
+  val Scheme = ":scheme"
+  val Path   = ":path"
+  val Authority = ":authority"
+
+  // Response pseudo header
+  val Status = ":status"
+}

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StageTools.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StageTools.scala
@@ -2,25 +2,11 @@ package org.http4s.blaze.http.http2
 
 import java.util.Locale
 
-import org.http4s.blaze.http.util.HeaderNames
-
 import scala.annotation.tailrec
 import scala.collection.generic.Growable
 import scala.collection.BitSet
 
-
 private object StageTools {
-  // Request pseudo headers
-  val Method = ":method"
-  val Scheme = ":scheme"
-  val Path   = ":path"
-  val Authority = ":authority"
-
-  // Response pseudo header
-  val Status = ":status"
-  val TE = "te"
-  val Connection = HeaderNames.Connection
-  val ContentLength = HeaderNames.ContentLength
 
   /** Copy HTTP headers from `source` to dest
     *

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ALPNServerSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ALPNServerSelector.scala
@@ -13,12 +13,15 @@ import scala.util.{Failure, Success}
 /** Dynamically inject an appropriate pipeline using ALPN
   *
   * @param engine the `SSLEngine` in use for the connection
-  * @param selector selects the preferred protocol from the seq of supported clients. May get an empty sequence.
+  * @param selector selects the preferred protocol from the seq of supported
+  *                 clients. May get an empty sequence.
   * @param builder builds the appropriate pipeline based on the
   */
-private[http] class ALPNServerSelector(engine: SSLEngine,
-                         selector: Set[String] => String,
-                         builder: String => LeafBuilder[ByteBuffer]) extends TailStage[ByteBuffer] {
+final class ALPNServerSelector(
+  engine: SSLEngine,
+  selector: Set[String] => String,
+  builder: String => LeafBuilder[ByteBuffer]
+) extends TailStage[ByteBuffer] {
 
   ALPN.put(engine, new ServerProvider)
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/RequestParser.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/RequestParser.scala
@@ -1,14 +1,15 @@
 package org.http4s.blaze.http.http2.server
 
-import org.http4s.blaze.http.http2.StageTools._
 import org.http4s.blaze.http.{BodyReader, HttpRequest, _}
+import org.http4s.blaze.http.http2.PseudoHeaders._
+import org.http4s.blaze.http.http2.StageTools._
 
 import scala.collection.mutable.ArrayBuffer
 
 /** Tool for turning a HEADERS frame into a request */
 private object RequestParser {
-  def makeRequest(hs: Headers, body: BodyReader): Either[String, HttpRequest] = {
 
+  def makeRequest(hs: Headers, body: BodyReader): Either[String, HttpRequest] = {
     val normalHeaders = new ArrayBuffer[(String, String)](math.max(0, hs.size - 3))
     var method: String = null
     var scheme: String = null
@@ -47,10 +48,10 @@ private object RequestParser {
       case h@(k, v) => // Non pseudo headers
         pseudoDone = true
         k match {
-          case Connection =>
+          case HeaderNames.Connection =>
             error += s"HTTP/2.0 forbids connection specific headers: $h. "
 
-          case TE =>
+          case HeaderNames.TE =>
             if (!v.equalsIgnoreCase("trailers")) error += "HTTP/2.0 forbids TE header values other than 'trailers'. "
           // ignore otherwise
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerPriorKnowledgeHandshaker.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerPriorKnowledgeHandshaker.scala
@@ -11,7 +11,7 @@ import org.http4s.blaze.util.{BufferTools, Execution, StageTools}
 import scala.concurrent.Future
 import scala.util.Failure
 
-private[http] class ServerPriorKnowledgeHandshaker(
+final class ServerPriorKnowledgeHandshaker(
     localSettings: ImmutableHttp2Settings,
     flowStrategy: FlowStrategy,
     nodeBuilder: Int => LeafBuilder[StreamFrame])

--- a/http/src/main/scala/org/http4s/blaze/http/util/HeaderTools.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/util/HeaderTools.scala
@@ -4,6 +4,8 @@ import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
+import org.http4s.blaze.http.HeaderNames
+
 private[blaze] object HeaderTools {
 
   private case class CachedDateHeader(acquired: Long, header: String)

--- a/http/src/main/scala/org/http4s/blaze/http/util/ServiceTimeoutFilter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/util/ServiceTimeoutFilter.scala
@@ -1,6 +1,6 @@
 package org.http4s.blaze.http.util
 
-import org.http4s.blaze.http.{HttpService, RouteAction}
+import org.http4s.blaze.http.{HeaderNames, HttpService, RouteAction}
 import org.http4s.blaze.util.Execution
 
 import scala.concurrent.duration.Duration

--- a/http/src/test/scala/org/http4s/blaze/http/http2/client/ClientStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/client/ClientStageSpec.scala
@@ -6,12 +6,13 @@ import org.http4s.blaze.http.http2._
 import org.http4s.blaze.http.http2.mocks.MockHeadStage
 import org.http4s.blaze.http.{BodyReader, HttpRequest}
 import org.http4s.blaze.pipeline.{Command, LeafBuilder}
-import org.http4s.blaze.util.{BufferTools, Execution}
+import org.http4s.blaze.util.BufferTools
 import org.specs2.mutable.Specification
 
 import scala.util.{Failure, Success, Try}
 
 class ClientStageSpec extends Specification {
+  import PseudoHeaders._
 
   private val request = HttpRequest(
     method = "GET",
@@ -25,16 +26,16 @@ class ClientStageSpec extends Specification {
   private val resp = HeadersFrame(
     priority = Priority.NoPriority,
     endStream = true,
-    headers = Seq(StageTools.Status -> "200")
+    headers = Seq(Status -> "200")
   )
 
   "ClientStage" >> {
     "make appropriate pseudo headers" >> {
       ClientStage.makeHeaders(request) must_== Try(Vector(
-        StageTools.Method -> "GET",
-        StageTools.Scheme -> "https",
-        StageTools.Authority -> "foo.com",
-        StageTools.Path -> "/Foo?Bar",
+        Method -> "GET",
+        Scheme -> "https",
+        Authority -> "foo.com",
+        Path -> "/Foo?Bar",
         "not-lower-case" -> "Value"
       ))
     }


### PR DESCRIPTION
We made a lot of the API private, but some of it should be made public
again for consumption by http4s proper.