### PR TITLE
Release v0.14.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import BlazePlugin._
 organization in ThisBuild := "org.http4s"
 
 lazy val commonSettings = Seq(
-  version := "0.14.0-SNAPSHOT",
+  version := "0.14.0-M2",
   description := "NIO Framework for Scala",
   crossScalaVersions := Seq("2.11.11", scalaVersion.value),
   scalacOptions in (Compile, doc) ++= Seq("-no-link-warnings") // Suppresses problems with Scaladoc @throws links


### PR DESCRIPTION
A milestone which should allow http4s proper to use the 0.14.0.x line.