### PR TITLE
Cleanup NIO1SocketServerGroup

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/FixedSelectorPool.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/FixedSelectorPool.scala
@@ -1,0 +1,27 @@
+package org.http4s.blaze.channel.nio1
+
+import java.nio.channels.Selector
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Provides a fixed size pool of [[SelectorLoop]]s, distributing work in a round robin fashion */
+class FixedSelectorPool(poolSize: Int, bufferSize: Int) extends SelectorLoopPool {
+
+  private val loops = 0
+    .until(poolSize)
+    .map { id =>
+      val l = new SelectorLoop(s"blaze-nio-fixed-selector-pool-$id", Selector.open(), bufferSize)
+      l.setDaemon(true)
+      l.start()
+      l
+    }
+    .toArray
+
+  private val _nextLoop = new AtomicInteger(0)
+
+  def nextLoop(): SelectorLoop = {
+    val l = math.abs(_nextLoop.incrementAndGet() % poolSize)
+    loops(l)
+  }
+
+  def shutdown(): Unit = loops.foreach(_.close())
+}

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoopPool.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoopPool.scala
@@ -1,40 +1,11 @@
 package org.http4s.blaze.channel.nio1
 
-import java.nio.channels.Selector
-import java.util.concurrent.atomic.AtomicInteger
-
 /** Provides [[SelectorLoop]]s for NIO1 network services */
 trait SelectorLoopPool {
 
-  /** Get the next loop with which to attach a connection
-    *
-    * The loop is not guaranteed to be used
-    */
+  /** Get the next loop with which to attach a connection */
   def nextLoop(): SelectorLoop
 
-  /** Shut down all the selector loops */
+  /** Shut down all the [[SelectorLoop]]s */
   def shutdown(): Unit
-}
-
-/** Provides a fixed size pool of [[SelectorLoop]]s, distributing work in a round robin fashion */
-class FixedSelectorPool(poolSize: Int, bufferSize: Int) extends SelectorLoopPool {
-
-  private val loops = 0
-    .until(poolSize)
-    .map { id =>
-      val l = new SelectorLoop(s"blaze-nio-fixed-selector-pool-$id", Selector.open(), bufferSize)
-      l.setDaemon(true)
-      l.start()
-      l
-    }
-    .toArray
-
-  private val _nextLoop = new AtomicInteger(0)
-
-  def nextLoop(): SelectorLoop = {
-    val l = math.abs(_nextLoop.incrementAndGet() % poolSize)
-    loops(l)
-  }
-
-  def shutdown(): Unit = loops.foreach(_.close())
 }

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/ServerChannelImpl.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/ServerChannelImpl.scala
@@ -1,0 +1,26 @@
+package org.http4s.blaze.channel.nio1
+
+import java.net.InetSocketAddress
+import java.nio.channels.ServerSocketChannel
+
+import org.http4s.blaze.channel.{BufferPipelineBuilder, ServerChannel}
+
+import scala.util.control.NonFatal
+
+/** Implementation of a [[ServerChannel]] for nio1 */
+private class ServerChannelImpl(
+    val serverSocketChannel: ServerSocketChannel,
+    val service: BufferPipelineBuilder)
+    extends ServerChannel {
+
+  override protected def closeChannel(): Unit = {
+    logger.info(s"Closing NIO1 channel ${serverSocketChannel.getLocalAddress}")
+    try serverSocketChannel.close()
+    catch {
+      case NonFatal(t) => logger.debug(t)("Failure during channel close")
+    }
+  }
+
+  def socketAddress: InetSocketAddress =
+    serverSocketChannel.getLocalAddress.asInstanceOf[InetSocketAddress]
+}

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SocketChannelHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SocketChannelHead.scala
@@ -1,0 +1,88 @@
+package org.http4s.blaze.channel.nio1
+
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.channels.{ClosedChannelException, SelectionKey, SocketChannel}
+
+import org.http4s.blaze.channel.ChannelHead.brokePipeMessages
+import org.http4s.blaze.channel.nio1.NIO1HeadStage.{Complete, Incomplete, WriteError, WriteResult}
+import org.http4s.blaze.pipeline.Command.EOF
+import org.http4s.blaze.util
+import org.http4s.blaze.util.BufferTools
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
+/** Implementation of the channel head that can deal explicitly with a SocketChannel */
+private class SocketChannelHead(ch: SocketChannel, loop: SelectorLoop, key: SelectionKey)
+    extends NIO1HeadStage(ch, loop, key) {
+  override protected def performRead(scratch: ByteBuffer): Try[ByteBuffer] =
+    try {
+      scratch.clear()
+      val bytes = ch.read(scratch)
+      if (bytes >= 0) {
+        scratch.flip()
+
+        val b = ByteBuffer.allocate(scratch.remaining())
+        b.put(scratch)
+        b.flip()
+        Success(b)
+      } else Failure(EOF)
+
+    } catch {
+      case e: ClosedChannelException => Failure(EOF)
+      case e: IOException if brokePipeMessages.contains(e.getMessage) =>
+        Failure(EOF)
+      case e: IOException => Failure(e)
+    }
+
+  override protected def performWrite(
+      scratch: ByteBuffer,
+      buffers: Array[ByteBuffer]): WriteResult =
+    try {
+      if (BufferTools.areDirectOrEmpty(buffers)) {
+        ch.write(buffers)
+        if (util.BufferTools.checkEmpty(buffers)) Complete
+        else Incomplete
+      } else {
+        // To sidestep the java NIO "memory leak" (see http://www.evanjones.ca/java-bytebuffer-leak.html)
+        // We copy the data to the scratch buffer (which should be a direct ByteBuffer)
+        // before the write. We then check to see how much data was written and fast-forward
+        // the input buffers accordingly.
+        // This is very similar to the pattern used by the Oracle JDK implementation in its
+        // IOUtil class: if the provided buffers are not direct buffers, they are copied to
+        // temporary direct ByteBuffers and written.
+        @tailrec
+        def writeLoop(): WriteResult = {
+          scratch.clear()
+          BufferTools.copyBuffers(buffers, scratch)
+          scratch.flip()
+
+          val written = ch.write(scratch)
+          if (written > 0) {
+            assert(BufferTools.fastForwardBuffers(buffers, written))
+          }
+
+          if (scratch.remaining() > 0) {
+            // Couldn't write all the data
+            Incomplete
+          } else if (util.BufferTools.checkEmpty(buffers)) {
+            // All data was written
+            Complete
+          } else {
+            // May still be able to write more to the socket buffer
+            writeLoop()
+          }
+        }
+
+        writeLoop()
+      }
+    } catch {
+      case _: ClosedChannelException => WriteError(EOF)
+      case e: IOException if brokePipeMessages.contains(e.getMessage) =>
+        WriteError(EOF)
+      case e: IOException =>
+        logger.warn(e)("Error writing to channel")
+        WriteError(e)
+    }
+}


### PR DESCRIPTION
It was a monolithic body of code, mostly condensed into one method. It
was broken down into methods and a number of classes moved to their own
files.