### PR TITLE
NIO1 event loops use a ThreadFactory to spawn threads

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/ServerChannelGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ServerChannelGroup.scala
@@ -7,6 +7,11 @@ import org.log4s.getLogger
 
 import scala.util.Try
 
+/** Abstraction for binding a server socket and handling connections.
+  *
+  * @note Implementations may have resources associated with
+  *       them before binding any sockets and should be closed.
+  */
 abstract class ServerChannelGroup {
   protected val logger = getLogger
 

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/FixedSelectorPool.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/FixedSelectorPool.scala
@@ -1,27 +1,30 @@
 package org.http4s.blaze.channel.nio1
 
 import java.nio.channels.Selector
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.annotation.tailrec
 
 /** Provides a fixed size pool of [[SelectorLoop]]s, distributing work in a round robin fashion */
-class FixedSelectorPool(poolSize: Int, bufferSize: Int) extends SelectorLoopPool {
+final class FixedSelectorPool(
+    poolSize: Int,
+    bufferSize: Int,
+    threadFactory: ThreadFactory
+) extends SelectorLoopPool {
+  require(poolSize > 0, s"Invalid pool size: $poolSize")
 
-  private val loops = 0
-    .until(poolSize)
-    .map { id =>
-      val l = new SelectorLoop(s"blaze-nio-fixed-selector-pool-$id", Selector.open(), bufferSize)
-      l.setDaemon(true)
-      l.start()
-      l
-    }
-    .toArray
-
-  private val _nextLoop = new AtomicInteger(0)
-
-  def nextLoop(): SelectorLoop = {
-    val l = math.abs(_nextLoop.incrementAndGet() % poolSize)
-    loops(l)
+  private[this] val next = new AtomicLong(0L)
+  private[this] val loops = Array.fill(poolSize) {
+    new SelectorLoop(Selector.open(), bufferSize, threadFactory)
   }
 
-  def shutdown(): Unit = loops.foreach(_.close())
+  @tailrec
+  def nextLoop(): SelectorLoop = {
+    val i = next.get
+    if (next.compareAndSet(i, (i + 1L) % poolSize)) loops(i.toInt)
+    else nextLoop()
+  }
+
+  def close(): Unit = loops.foreach(_.close())
 }

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketConnection.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketConnection.scala
@@ -23,7 +23,7 @@ object NIO1Connection {
 
 }
 
-case class NIO1SocketConnection(connection: SocketChannel) extends SocketConnection {
+private case class NIO1SocketConnection(connection: SocketChannel) extends SocketConnection {
 
   override def remote: SocketAddress = connection.getRemoteAddress
 

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -94,7 +94,7 @@ final class SelectorLoop(
   override def execute(runnable: Runnable): Unit = enqueueTask(runnable)
 
   override def reportFailure(cause: Throwable): Unit =
-    logger.info(cause)(s"Exception executing task in selector look $threadName")
+    logger.info(cause)(s"Exception executing task in selector loop $threadName")
 
   /** Initialize a new `Selectable` channel
     *

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoopPool.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoopPool.scala
@@ -7,5 +7,5 @@ trait SelectorLoopPool {
   def nextLoop(): SelectorLoop
 
   /** Shut down all the [[SelectorLoop]]s */
-  def shutdown(): Unit
+  def close(): Unit
 }

--- a/core/src/main/scala/org/http4s/blaze/channel/package.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/package.scala
@@ -7,10 +7,9 @@ package object channel {
 
   type BufferPipelineBuilder = SocketConnection => LeafBuilder[ByteBuffer]
 
-  /** Default number of threads used to make a new [[SelectorLoopPool]] if not specified */
+  /** Default number of threads used to make a new
+    * [[org.http4s.blaze.channel.nio1.SelectorLoopPool]] if not specified
+    * */
   val DefaultPoolSize: Int =
     math.max(4, Runtime.getRuntime.availableProcessors() + 1)
-
-  @deprecated("Renamed to DefaultPoolSize", "0.14.0")
-  val defaultPoolSize: Int = DefaultPoolSize
 }

--- a/core/src/main/scala/org/http4s/blaze/util/BasicThreadFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/BasicThreadFactory.scala
@@ -1,0 +1,25 @@
+package org.http4s.blaze.util
+
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+private[blaze] object BasicThreadFactory {
+
+  /** Construct a basic `ThreadFactory`
+    *
+    * Resulting threads are named with their prefix plus '-unique_id'
+    * where unique id is an increasing integer.
+    */
+  def apply(prefix: String, daemonThreads: Boolean): ThreadFactory =
+    new Impl(prefix, daemonThreads)
+
+  private[this] class Impl(prefix: String, daemonThreads: Boolean) extends ThreadFactory {
+    private[this] val next = new AtomicInteger(0)
+    override def newThread(r: Runnable): Thread = {
+      val id = next.getAndIncrement()
+      val thread = new Thread(r, s"$prefix-$id")
+      thread.setDaemon(daemonThreads)
+      thread
+    }
+  }
+}


### PR DESCRIPTION
Closes #183.

Using a ThreadFactory to generate the threads for the SelectorLoops
and NIO1SocketServerGroup gives users an easy way to control how
threads are created and their properties.