### PR TITLE
Remove the `Disconnected` command

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -9,7 +9,6 @@ import scala.concurrent.{Future, Promise}
 import java.nio.channels._
 import java.nio.ByteBuffer
 import java.io.IOException
-import java.util.Date
 import java.util.concurrent.TimeUnit
 import java.lang.{Long => JLong}
 
@@ -18,15 +17,15 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
 
   def name: String = "ByteBufferHeadStage"
 
-  private val buffer = ByteBuffer.allocateDirect(bufferSize)
+  @volatile
+  private[this] var closeReason: Throwable = null
+  private[this] val buffer = ByteBuffer.allocateDirect(bufferSize)
 
-  override def writeRequest(data: ByteBuffer): Future[Unit] =
-    if (!data.hasRemaining() && data.position > 0) {
-      logger.warn(
-        "Received write request with non-zero position but ZERO available" +
-          s"bytes at ${new Date} on org.http4s.blaze.channel $channel: $data")
-      Future.successful(())
-    } else {
+  override def writeRequest(data: ByteBuffer): Future[Unit] = {
+    val reason = closeReason
+    if (reason != null) Future.failed(reason)
+    else if (!data.hasRemaining) Future.successful(())
+    else {
       val p = Promise[Unit]
       def go(i: Int): Unit =
         channel.write(
@@ -35,26 +34,30 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
           new CompletionHandler[Integer, Null] {
             def failed(exc: Throwable, attachment: Null): Unit = {
               val e = checkError(exc)
-              sendInboundCommand(Disconnected)
               closeWithError(e)
-              p.tryFailure(e)
+              p.failure(e)
               ()
             }
 
-            def completed(result: Integer, attachment: Null): Unit = {
-              if (result.intValue < i)
-                go(i - result.intValue) // try to write again
-              else p.trySuccess(()); () // All done
-            }
+            def completed(result: Integer, attachment: Null): Unit =
+              if (result.intValue < i) go(i - result.intValue) // try to write again
+              else {
+                // All done
+                p.success(())
+                ()
+              }
           }
         )
       go(data.remaining())
 
       p.future
     }
+  }
 
-  override def writeRequest(data: Seq[ByteBuffer]): Future[Unit] =
-    if (data.isEmpty) Future.successful(())
+  override def writeRequest(data: Seq[ByteBuffer]): Future[Unit] = {
+    val reason = closeReason
+    if (closeReason != null) Future.failed(reason)
+    else if (data.isEmpty) Future.successful(())
     else {
       val p = Promise[Unit]
       val srcs = data.toArray
@@ -70,21 +73,25 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
           new CompletionHandler[JLong, Null] {
             def failed(exc: Throwable, attachment: Null): Unit = {
               val e = checkError(exc)
-              sendInboundCommand(Disconnected)
               closeWithError(e)
               p.tryFailure(e)
               ()
             }
 
             def completed(result: JLong, attachment: Null): Unit =
-              if (BufferTools.checkEmpty(srcs)) { p.trySuccess(()); () } else
-                go(BufferTools.dropEmpty(srcs))
+              if (!BufferTools.checkEmpty(srcs)) go(BufferTools.dropEmpty(srcs))
+              else {
+                p.success(())
+                ()
+              }
           }
         )
+
       go(0)
 
       p.future
     }
+  }
 
   def readRequest(size: Int): Future[ByteBuffer] = {
     val p = Promise[ByteBuffer]
@@ -100,25 +107,25 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
       new CompletionHandler[Integer, Null] {
         def failed(exc: Throwable, attachment: Null): Unit = {
           val e = checkError(exc)
-          sendInboundCommand(Disconnected)
-          closeWithError(e)
-          p.tryFailure(e)
+          p.failure(e)
           ()
         }
 
-        def completed(i: Integer, attachment: Null): Unit =
-          if (i.intValue() >= 0) {
+        def completed(i: Integer, attachment: Null): Unit = i.intValue match {
+          case 0 =>
+            p.success(BufferTools.emptyBuffer)
+            ()
+
+          case i if i < 0 =>
+            p.failure(EOF)
+
+          case i =>
             buffer.flip()
-            val b = ByteBuffer.allocate(buffer.remaining())
+            val b = ByteBuffer.allocate(buffer.remaining)
             b.put(buffer).flip()
-            p.trySuccess(b)
+            p.success(b)
             ()
-          } else { // must be end of stream
-            sendInboundCommand(Disconnected)
-            closeWithError(EOF)
-            p.tryFailure(EOF)
-            ()
-          }
+        }
       }
     )
     p.future
@@ -135,12 +142,22 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
   override protected def stageShutdown(): Unit = closeWithError(EOF)
 
   override protected def closeWithError(t: Throwable): Unit = {
+    val needsClose = synchronized {
+      val reason = closeReason
+      if (reason == null || closeReason == EOF) {
+        closeReason = t
+      }
+      reason == null
+    }
+
     t match {
       case EOF => logger.debug(s"closeWithError(EOF)")
       case t => logger.error(t)("NIO2 channel closed with an unexpected error")
     }
 
-    try channel.close()
-    catch { case e: IOException => /* Don't care */ }
+    if (needsClose) {
+      try channel.close()
+      catch { case e: IOException => /* Don't care */ }
+    }
   }
 }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Command.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Command.scala
@@ -15,14 +15,8 @@ object Command {
   /** Signals that the pipeline [[HeadStage]] is connected and ready to accept read and write requests */
   case object Connected extends InboundCommand
 
-  /** Signals the tails desire to shutdown. No [[Disconnected]] command should be sent in reply */
+  /** Signals the tails desire to shutdown. */
   case object Disconnect extends OutboundCommand
-
-  /** Signals to the tail of the pipeline that it has been disconnected and
-    * shutdown. Any following reads or writes will result in an exception, [[EOF]],
-    * a general Exception signaling the stage is not connected, or otherwise.
-    */
-  case object Disconnected extends InboundCommand
 
   /** Signals the the stages a desire to flush the pipeline. This is just a suggestion
     * and is not guaranteed to induce any effect. */

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -1,6 +1,5 @@
 package org.http4s.blaze.pipeline
 
-import java.util.Date
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.{Future, Promise}
@@ -32,7 +31,7 @@ import scala.util.control.NonFatal
  */
 
 sealed trait Stage {
-  final protected val logger = getLogger
+  final protected val logger = getLogger(this.getClass)
 
   def name: String
 
@@ -44,18 +43,18 @@ sealed trait Stage {
     * times by misbehaving stages. It is therefore recommended that the method be idempotent.
     */
   protected def stageStartup(): Unit =
-    logger.debug(s"${getClass.getSimpleName} starting up at ${new Date}")
+    logger.debug(s"Starting up.")
 
   /** Shuts down the stage, deallocating resources, etc.
     *
-    * This method will be called when the stages receives a [[Disconnected]] command unless the
+    * This method will be called when the stages receives a [[Disconnect]] command unless the
     * `inboundCommand` method is overridden. It is not impossible that this will not be called
     * due to failure for other stages to propagate shutdown commands. Conversely, it is also
     * possible for this to be called more than once due to the reception of multiple disconnect
     * commands. It is therefore recommended that the method be idempotent.
     */
   protected def stageShutdown(): Unit =
-    logger.debug(s"${getClass.getSimpleName} shutting down at ${new Date}")
+    logger.debug(s"Shutting down.")
 
   /** Handle basic startup and shutdown commands.
     * This should clearly be overridden in all cases except possibly TailStages
@@ -64,7 +63,6 @@ sealed trait Stage {
     */
   def inboundCommand(cmd: InboundCommand): Unit = cmd match {
     case Connected => stageStartup()
-    case Disconnected => stageShutdown()
     case _ => logger.warn(s"$name received unhandled inbound command: $cmd")
   }
 }
@@ -167,7 +165,6 @@ sealed trait Tail[I] extends Stage {
     if (this._prevStage != null) {
       this match {
         case m: MidStage[_, _] =>
-          m.sendInboundCommand(Disconnected)
           m._nextStage = null
 
         case _ => // NOOP, must be a TailStage

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/TimeoutStageBase.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/TimeoutStageBase.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import org.http4s.blaze.pipeline.MidStage
-import org.http4s.blaze.pipeline.Command.{Disconnect, Disconnected}
+import org.http4s.blaze.pipeline.Command.Disconnect
 import org.http4s.blaze.util.{Cancellable, TickWheelExecutor}
 
 import java.util.concurrent.atomic.AtomicReference
@@ -28,7 +28,6 @@ abstract class TimeoutStageBase[T](timeout: Duration, exec: TickWheelExecutor)
     override def run(): Unit = {
       logger.debug(s"Timeout of $timeout triggered. Killing pipeline.")
       sendOutboundCommand(Disconnect)
-      sendInboundCommand(Disconnected)
     }
   }
 

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -39,8 +39,6 @@ class QuietTimeoutStageSpec extends TimeoutHelpers {
       pipe.sendOutboundCommand(Command.Disconnect)
 
       checkFuture(f, 5.second) should throwA[Command.EOF.type]
-      Thread.sleep(4000)
-      pipe.getDisconnects must_==(0)
     }
   }
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerStage.scala
@@ -71,7 +71,7 @@ class Http1ServerStage(service: HttpService, config: HttpServerStageConfig)
             case Success(Http1ServerCodec.Reload) =>
               dispatchLoop() // continue the loop
             case Success(Http1ServerCodec.Close) =>
-              sendOutboundCommand(Cmd.Disconnect) // not able to server another on this session
+              shutdownWithCommand(Cmd.Disconnect) // not able to server another on this session
 
             case Failure(EOF) => /* NOOP socket should now be closed */
             case Failure(ex) =>
@@ -79,7 +79,8 @@ class Http1ServerStage(service: HttpService, config: HttpServerStageConfig)
               shutdownWithCommand(Cmd.Error(ex))
           }
 
-        case Failure(EOF) => /* NOOP */
+        case Failure(EOF) =>
+          shutdownWithCommand(Cmd.Disconnect)
         case Failure(ex) =>
           logger.error(ex)("Failed to service request. Sending 500 response.")
           codec


### PR DESCRIPTION
As part of the effort to remove the `InboundCommand`s from the Stage
architecture (#189), this removes the `Disconnected` command. The result
is that it is up to the user of the pipeline to free resources and is not
notified eagerly about detected disconnects. In practice, this isn't all
that useful since socket events are similarly lazy: I/O operations are
typically required to detect disconnects, so the pipelines ends up getting
a `Disconnected` command pushed to them and a `EOF` result in an
operation.