### PR TITLE
ServerChannelGroup.acceptConnection is moved to `BufferedPipelinebuilder`

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/ServerChannelGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ServerChannelGroup.scala
@@ -12,20 +12,11 @@ import scala.util.Try
   * @note Implementations may have resources associated with
   *       them before binding any sockets and should be closed.
   */
-abstract class ServerChannelGroup {
-  protected val logger = getLogger
+trait ServerChannelGroup {
 
   /** Create a [[ServerChannel]] that will serve the service on the specified socket */
-  def bind(address: InetSocketAddress, service: BufferPipelineBuilder): Try[ServerChannel]
+  def bind(address: InetSocketAddress, service: SocketPipelineBuilder): Try[ServerChannel]
 
   /** Closes the group along with all current connections. */
   def closeGroup(): Unit
-
-  /** Decide whether to accept the incoming connection or not
-    *
-    * Should also be used for any requisite logging purposes. */
-  protected def acceptConnection(address: InetSocketAddress): Boolean = {
-    logger.info(s"Connection from $address accepted at ${new Date}.")
-    true
-  }
 }

--- a/core/src/main/scala/org/http4s/blaze/channel/package.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/package.scala
@@ -1,11 +1,14 @@
 package org.http4s.blaze
 
 import java.nio.ByteBuffer
+
 import org.http4s.blaze.pipeline.LeafBuilder
+
+import scala.concurrent.Future
 
 package object channel {
 
-  type BufferPipelineBuilder = SocketConnection => LeafBuilder[ByteBuffer]
+  type SocketPipelineBuilder = SocketConnection => Future[LeafBuilder[ByteBuffer]]
 
   /** Default number of threads used to make a new
     * [[org.http4s.blaze.channel.nio1.SelectorLoopPool]] if not specified

--- a/core/src/main/scala/org/http4s/blaze/pipeline/PipelineBuilder.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/PipelineBuilder.scala
@@ -32,9 +32,6 @@ final class LeafBuilder[I] private[pipeline] (leaf: Tail[I]) {
 
 object LeafBuilder {
   def apply[T](leaf: TailStage[T]): LeafBuilder[T] = new LeafBuilder[T](leaf)
-
-  implicit def tailToLeaf[I](tail: TailStage[I]): LeafBuilder[I] =
-    LeafBuilder(tail)
 }
 
 /** Facilitates starting a pipeline from a MidStage. Can be appended and prepended

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/monitors/ConnectionMonitor.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/monitors/ConnectionMonitor.scala
@@ -3,8 +3,9 @@ package org.http4s.blaze.pipeline.stages.monitors
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicBoolean
 
-import org.http4s.blaze.channel.BufferPipelineBuilder
+import org.http4s.blaze.channel.{SocketConnection, SocketPipelineBuilder}
 import org.http4s.blaze.pipeline.MidStage
+import org.http4s.blaze.util.Execution
 import org.http4s.blaze.util.Execution.directec
 
 import scala.concurrent.Future
@@ -12,8 +13,8 @@ import scala.concurrent.Future
 /** Facilitates injecting some monitoring tools into the pipeline */
 abstract class ConnectionMonitor {
 
-  def wrapBuilder(factory: BufferPipelineBuilder): BufferPipelineBuilder =
-    factory.andThen(_.prepend(new ServerStatusStage))
+  def wrapBuilder(factory: SocketPipelineBuilder): SocketPipelineBuilder =
+    factory(_).map(_.prepend(new ServerStatusStage))(Execution.trampoline)
 
   protected def connectionAccepted(): Unit
   protected def connectionClosed(): Unit

--- a/examples/src/main/scala/org/http4s/blaze/examples/EchoServer.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/EchoServer.scala
@@ -1,12 +1,13 @@
 package org.http4s.blaze
 package examples
 
-import org.http4s.blaze.pipeline.TailStage
+import org.http4s.blaze.pipeline.{LeafBuilder, TailStage}
 import java.nio.ByteBuffer
+
 import org.http4s.blaze.util.BufferTools
 
 import scala.util.{Failure, Success}
-import org.http4s.blaze.channel.{BufferPipelineBuilder, ServerChannel}
+import org.http4s.blaze.channel.{ServerChannel, SocketPipelineBuilder}
 import java.net.InetSocketAddress
 import java.util.Date
 
@@ -15,11 +16,13 @@ import org.http4s.blaze.pipeline.Command.EOF
 import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
 import org.log4s.getLogger
 
+import scala.concurrent.Future
+
 class EchoServer {
   private[this] val logger = getLogger
 
   def prepare(address: InetSocketAddress): ServerChannel = {
-    val f: BufferPipelineBuilder = _ => new EchoStage
+    val f: SocketPipelineBuilder = _ => Future.successful(LeafBuilder(new EchoStage))
 
     NIO2SocketServerGroup()
       .bind(address, f)

--- a/examples/src/main/scala/org/http4s/blaze/examples/Http1ServerExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/Http1ServerExample.scala
@@ -14,6 +14,7 @@ import org.http4s.blaze.pipeline.stages.SSLStage
 import org.http4s.blaze.pipeline.LeafBuilder
 import org.http4s.blaze.pipeline.stages.monitors.IntervalConnectionMonitor
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class Http1ServerExample(factory: ServerChannelGroup, port: Int)(
@@ -23,11 +24,11 @@ class Http1ServerExample(factory: ServerChannelGroup, port: Int)(
 
   def run(): ServerChannel = {
     val ref = new AtomicReference[ServerChannel](null)
-    val f: BufferPipelineBuilder =
+    val f: SocketPipelineBuilder =
       status.wrapBuilder { _ =>
         val stage =
           new Http1ServerStage(ExampleService.service(Some(status), Some(ref)), config)
-        trans(LeafBuilder(stage))
+        Future.successful(trans(LeafBuilder(stage)))
       }
 
     val address = new InetSocketAddress(port)

--- a/examples/src/main/scala/org/http4s/blaze/examples/http2/Http2ServerExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/http2/Http2ServerExample.scala
@@ -11,6 +11,8 @@ import org.http4s.blaze.http.http2.server.ServerSelector
 import org.http4s.blaze.pipeline.TrunkBuilder
 import org.http4s.blaze.pipeline.stages.SSLStage
 
+import scala.concurrent.Future
+
 /** Basic HTTP/2 server example
   *
   * The server is capable of serving traffic over both HTTP/1.x and HTTP/2
@@ -24,11 +26,12 @@ import org.http4s.blaze.pipeline.stages.SSLStage
 class Http2ServerExample(port: Int) {
   private val sslContext = ExampleKeystore.sslContext()
 
-  private val f: BufferPipelineBuilder = { _ =>
+  private val f: SocketPipelineBuilder = { _ =>
     val eng = sslContext.createSSLEngine()
     eng.setUseClientMode(false)
-    TrunkBuilder(new SSLStage(eng))
-      .cap(ServerSelector(eng, ExampleService.service(None), HttpServerStageConfig()))
+    Future.successful(
+      TrunkBuilder(new SSLStage(eng))
+        .cap(ServerSelector(eng, ExampleService.service(None), HttpServerStageConfig())))
   }
 
   private val factory =

--- a/http/src/test/scala/org/http4s/blaze/http/endtoend/scaffolds/ServerScaffold.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/endtoend/scaffolds/ServerScaffold.scala
@@ -6,6 +6,8 @@ import java.nio.ByteBuffer
 import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
 import org.http4s.blaze.pipeline.LeafBuilder
 
+import scala.concurrent.Future
+
 abstract class ServerScaffold {
 
   protected def newLeafBuilder(): LeafBuilder[ByteBuffer]
@@ -13,7 +15,7 @@ abstract class ServerScaffold {
   final def apply[T](f: InetSocketAddress => T): T = {
     val group = NIO2SocketServerGroup()
 
-    val ch = group.bind(new InetSocketAddress(0), _ => newLeafBuilder())
+    val ch = group.bind(new InetSocketAddress(0), _ => Future.successful(newLeafBuilder()))
       .getOrElse(sys.error("Failed to start server."))
 
     try f(ch.socketAddress)


### PR DESCRIPTION
Closes #184.

The `acceptConnection` method is in a silly place in that the
`ServerSocketGroup` represents a collection of resources that are
capible of listening for socket connections. It is the wrong place to be
defining the logic for accepting or rejecting connections. This is
better done via changing the definition of `BufferPipelineBuilder` from
`SocketConnection => LeafBuilder[ByteBuffer]`
to
`SocketConnection => Option[LeafBuilder[ByteBuffer]]`
It also makes sense to rename `BufferPipelineBuilder` to
`SocketPipelineBuilder` since it must be dealing in `SocketConnection`s.