### PR TITLE
Tails are in charge of closing resources

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/ChannelHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ChannelHead.scala
@@ -15,16 +15,18 @@ trait ChannelHead extends HeadStage[ByteBuffer] {
     * This method should __not__ send a [[Disconnected]] command. */
   protected def closeWithError(t: Throwable): Unit
 
-  override def outboundCommand(cmd: OutboundCommand): Unit = cmd match {
+  final override protected def stageShutdown(): Unit = closeWithError(EOF)
+
+  final override def outboundCommand(cmd: OutboundCommand): Unit = cmd match {
     case Disconnect => closeWithError(EOF)
     case Error(e) => closeWithError(e)
-    case cmd => // NOOP
+    case _ => // NOOP
   }
 
   /** Filter the error, replacing known "EOF" like errors with EOF */
   protected def checkError(e: Throwable): Throwable = e match {
     case EOF => EOF
-    case e: ClosedChannelException => EOF
+    case _: ClosedChannelException => EOF
     case e: IOException if brokePipeMessages.contains(e.getMessage) => EOF
     case e: IOException =>
       logger.warn(e)("Channel IOException not known to be a disconnect error")

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Command.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Command.scala
@@ -15,7 +15,7 @@ object Command {
   /** Signals that the pipeline [[HeadStage]] is connected and ready to accept read and write requests */
   case object Connected extends InboundCommand
 
-  /** Signals the tails desire to shutdown. No [[Disconnected]] command should be sent in reply */
+  /** Signals the tails desire to shutdown. */
   case object Disconnect extends OutboundCommand
 
   /** Signals to the tail of the pipeline that it has been disconnected and
@@ -25,7 +25,8 @@ object Command {
   case object Disconnected extends InboundCommand
 
   /** Signals the the stages a desire to flush the pipeline. This is just a suggestion
-    * and is not guaranteed to induce any effect. */
+    * and is not guaranteed to induce any effect.
+    */
   case object Flush extends OutboundCommand
 
   /** Signals to the entire pipeline that the [[HeadStage]] has been disconnected and

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -1,6 +1,5 @@
 package org.http4s.blaze.pipeline
 
-import java.util.Date
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.{Future, Promise}
@@ -32,7 +31,7 @@ import scala.util.control.NonFatal
  */
 
 sealed trait Stage {
-  final protected val logger = getLogger
+  final protected val logger = getLogger(this.getClass)
 
   def name: String
 
@@ -44,18 +43,18 @@ sealed trait Stage {
     * times by misbehaving stages. It is therefore recommended that the method be idempotent.
     */
   protected def stageStartup(): Unit =
-    logger.debug(s"${getClass.getSimpleName} starting up at ${new Date}")
+    logger.debug(s"Starting up.")
 
   /** Shuts down the stage, deallocating resources, etc.
     *
-    * This method will be called when the stages receives a [[Disconnected]] command unless the
+    * This method will be called when the stages receives a [[Disconnect]] command unless the
     * `inboundCommand` method is overridden. It is not impossible that this will not be called
     * due to failure for other stages to propagate shutdown commands. Conversely, it is also
     * possible for this to be called more than once due to the reception of multiple disconnect
     * commands. It is therefore recommended that the method be idempotent.
     */
   protected def stageShutdown(): Unit =
-    logger.debug(s"${getClass.getSimpleName} shutting down at ${new Date}")
+    logger.debug(s"Shutting down.")
 
   /** Handle basic startup and shutdown commands.
     * This should clearly be overridden in all cases except possibly TailStages
@@ -64,7 +63,6 @@ sealed trait Stage {
     */
   def inboundCommand(cmd: InboundCommand): Unit = cmd match {
     case Connected => stageStartup()
-    case Disconnected => stageShutdown()
     case _ => logger.warn(s"$name received unhandled inbound command: $cmd")
   }
 }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/TimeoutStageBase.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/TimeoutStageBase.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import org.http4s.blaze.pipeline.MidStage
-import org.http4s.blaze.pipeline.Command.{Disconnect, Disconnected}
+import org.http4s.blaze.pipeline.Command.Disconnect
 import org.http4s.blaze.util.{Cancellable, TickWheelExecutor}
 
 import java.util.concurrent.atomic.AtomicReference
@@ -28,7 +28,6 @@ abstract class TimeoutStageBase[T](timeout: Duration, exec: TickWheelExecutor)
     override def run(): Unit = {
       logger.debug(s"Timeout of $timeout triggered. Killing pipeline.")
       sendOutboundCommand(Disconnect)
-      sendInboundCommand(Disconnected)
     }
   }
 

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -39,8 +39,6 @@ class QuietTimeoutStageSpec extends TimeoutHelpers {
       pipe.sendOutboundCommand(Command.Disconnect)
 
       checkFuture(f, 5.second) should throwA[Command.EOF.type]
-      Thread.sleep(4000)
-      pipe.getDisconnects must_==(0)
     }
   }
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerStage.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import org.http4s.blaze.http.util.ServiceTimeoutFilter
 import org.http4s.blaze.http.{HttpRequest, HttpServerStageConfig, RouteAction, _}
-import org.http4s.blaze.pipeline.Command.EOF
+import org.http4s.blaze.pipeline.Command.{Disconnect, EOF}
 import org.http4s.blaze.pipeline.{Command => Cmd, _}
 import org.http4s.blaze.util.Execution
 
@@ -71,15 +71,19 @@ class Http1ServerStage(service: HttpService, config: HttpServerStageConfig)
             case Success(Http1ServerCodec.Reload) =>
               dispatchLoop() // continue the loop
             case Success(Http1ServerCodec.Close) =>
-              sendOutboundCommand(Cmd.Disconnect) // not able to server another on this session
+              shutdownWithCommand(Cmd.Disconnect) // not able to server another on this session
 
-            case Failure(EOF) => /* NOOP socket should now be closed */
+            case Failure(EOF) =>
+              logger.debug(EOF)("Failed to render response")
+              shutdownWithCommand(Disconnect)
+
             case Failure(ex) =>
               logger.error(ex)("Failed to render response")
               shutdownWithCommand(Cmd.Error(ex))
           }
 
-        case Failure(EOF) => /* NOOP */
+        case Failure(EOF) =>
+          shutdownWithCommand(Cmd.Disconnect)
         case Failure(ex) =>
           logger.error(ex)("Failed to service request. Sending 500 response.")
           codec


### PR DESCRIPTION
Right now, when a channel fails to read or write it fails the channel,
closing everything etc. This makes it impossible to handle half-closed
scenarios. Instead of the Head being in charge of releasing resources,
we move that responsibility to the tails. This allows them to interact
with a half closed socket.

Note: this doesn't yet allow half-closing a socket, though it is a
necessary step.