### PR TITLE
Make HTTP message toString safe by default

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -22,7 +22,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
   private[this] val buffer = ByteBuffer.allocateDirect(bufferSize)
 
   override def writeRequest(data: ByteBuffer): Future[Unit] =
-    writeRequest(data::Nil)
+    writeRequest(data :: Nil)
 
   override def writeRequest(data: Seq[ByteBuffer]): Future[Unit] = {
     val reason = closeReason

--- a/core/src/main/scala/org/http4s/blaze/util/Property.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/Property.scala
@@ -1,0 +1,25 @@
+package org.http4s.blaze.util
+
+/** Helper for defining behavior specific to properties */
+private[blaze] abstract class Property(default: Boolean) {
+  // This may not be the most robust way to fix up the names of objects.
+  final val name = getClass.getName.replace("$", "")
+
+  /** Get the value of the property if it is set */
+  final def get: Option[Boolean] = System.getProperty(name) match {
+    case null => None
+    case value => Some(value == "true")
+  }
+
+  /** Get the value of this property, defaulting to `false` if it is not set. */
+  final def apply(): Boolean = System.getProperty(name) match {
+    case null => default
+    case value => value == "true"
+  }
+
+  /** Set the value of this property */
+  final def set(value: Boolean): Unit = {
+    System.setProperty(name, value.toString)
+    ()
+  }
+}

--- a/http/src/main/scala/org/http4s/blaze/http/HttpRequest.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/HttpRequest.scala
@@ -15,4 +15,19 @@ case class HttpRequest(
     minorVersion: Int,
     headers: Headers,
     body: BodyReader
-)
+) {
+  private[this] def formatStr(headersString: String): String =
+    s"HttpRequest($method, $url, $majorVersion, $minorVersion, $headersString, $body)"
+
+  override def toString: String =
+    if (logsensitiveinfo()) sensitiveToString
+    else formatStr(headers.toString)
+
+  /** A String representation of this request that includes the headers
+    *
+    * @note it is generally a security flaw to log headers as they may contain
+    *       sensitive user data. As such, this method should be used sparingly
+    *       and almost never in a production environment.
+    */
+  def sensitiveToString: String = formatStr(headers.toString)
+}

--- a/http/src/main/scala/org/http4s/blaze/http/HttpResponsePrelude.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/HttpResponsePrelude.scala
@@ -6,4 +6,20 @@ package org.http4s.blaze.http
   * @param status Response message. This has no meaning for the protocol, its purely for human enjoyment.
   * @param headers Response headers.
   */
-case class HttpResponsePrelude(code: Int, status: String, headers: Headers)
+case class HttpResponsePrelude(code: Int, status: String, headers: Headers) {
+
+  private[this] def formatStr(headersString: String): String =
+    s"HttpResponsePrelude($code, $status, $headersString)"
+
+  override def toString: String =
+    if (logsensitiveinfo()) sensitiveToString
+    else formatStr("<headers hidden>")
+
+  /** A String representation of this response prelude that includes the headers
+    *
+    * @note it is generally a security flaw to log headers as they may contain
+    *       sensitive user data. As such, this method should be used sparingly
+    *       and almost never in a production environment.
+    */
+  def sensitiveToString: String = formatStr(headers.toString)
+}

--- a/http/src/main/scala/org/http4s/blaze/http/logsensitiveinfo.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/logsensitiveinfo.scala
@@ -1,0 +1,6 @@
+package org.http4s.blaze.http
+
+import org.http4s.blaze.util.Property
+
+/** Enable logging of sensitive information such as header values and request content */
+private[blaze] object logsensitiveinfo extends Property(default = false)


### PR DESCRIPTION
The HttpRequest and HttpResponsePrelude are case classes which will
expose the headers in the default `toString` method implementation.
Instead, we now implement a safe `toString` method but also provide an
`unsafeToString` method for cases where you really want them.