### PR TITLE
Remove the `Connect` command

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/Command.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Command.scala
@@ -9,9 +9,6 @@ object Command {
 
   trait OutboundCommand
 
-  /** Signals the stages desire to Connect. It may be attempting to read from the pipeline */
-  case object Connect extends OutboundCommand
-
   /** Signals that the pipeline [[HeadStage]] is connected and ready to accept read and write requests */
   case object Connected extends InboundCommand
 

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -275,7 +275,6 @@ sealed trait Head[O] extends Stage {
   /** Receives outbound commands
     * Override to capture commands. */
   def outboundCommand(cmd: OutboundCommand): Unit = cmd match {
-    case Connect => stageStartup()
     case Disconnect => stageShutdown()
     case Error(e) => logger.error(e)(s"$name received unhandled error command")
     case cmd => logger.warn(s"$name received unhandled outbound command: $cmd")

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamStateImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamStateImpl.scala
@@ -199,9 +199,6 @@ private abstract class StreamStateImpl(session: SessionCore) extends StreamState
   final override def outboundCommand(cmd: OutboundCommand): Unit =
     session.serialExecutor.execute(new Runnable {
       def run(): Unit = cmd match {
-        case Command.Connect =>
-          () // nop
-
         case Command.Disconnect =>
           closeWithError(None) // will send a RST_STREAM, if necessary
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientPriorKnowledgeHandshaker.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientPriorKnowledgeHandshaker.scala
@@ -41,7 +41,6 @@ private[http] class ClientPriorKnowledgeHandshaker(
   }
 
   override protected def handlePreface(): Future[ByteBuffer] = {
-    sendOutboundCommand(Command.Connect) // establish the pipeline
     channelWrite(bits.getPrefaceBuffer()).map { _ =>
       BufferTools.emptyBuffer
     }


### PR DESCRIPTION
Related to #198

Only the `ClientChannelFactory` is making client channels, and they
start life connected, so essentially the `Connect` command is dead code.
Seems like a good time to remove it.