### PR TITLE
Upgrade to http4s-websocket-0.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val dependencies = Seq(
 )
 
 lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "3.9.5"
-lazy val http4sWebsocket     = "org.http4s"                 %% "http4s-websocket"    % "0.2.0"
+lazy val http4sWebsocket     = "org.http4s"                 %% "http4s-websocket"    % "0.2.1"
 lazy val logbackClassic      = "ch.qos.logback"             %  "logback-classic"     % "1.2.3"
 lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.6.1"
 lazy val scalaXml =            "org.scala-lang.modules"     %% "scala-xml"           % "1.0.6"


### PR DESCRIPTION
Intent is to release this and http4s and get the new close handler without warnings about binary clashes.