### PR TITLE
Add ability to close a BodyWriter with an exception

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/BodyWriter.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/BodyWriter.scala
@@ -37,7 +37,10 @@ trait BodyWriter {
 
   /** Close the writer and flush any buffers
     *
+    * If the reason is `Some`, this means that the message was not completely written
+    * due to the provided error.
+    *
     * @return a `Future[Finished]` which will resolve once the close process has completed.
     */
-  def close(): Future[Finished]
+  def close(reason: Option[Throwable]): Future[Finished]
 }

--- a/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
@@ -58,7 +58,7 @@ object RouteAction {
         def go(): Unit = body.onComplete {
           case Failure(t) => p.tryFailure(t)
           case Success(buff) =>
-            if (!buff.hasRemaining) p.completeWith(writer.close())
+            if (!buff.hasRemaining) p.completeWith(writer.close(None))
             else
               writer.write(buff).onComplete {
                 case Success(_) => go()
@@ -91,7 +91,7 @@ object RouteAction {
 
         writer
           .write(body.asReadOnlyBuffer())
-          .flatMap(_ => writer.close())(Execution.directec)
+          .flatMap(_ => writer.close(None))(Execution.directec)
       }
     }
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/InboundStreamStateImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/InboundStreamStateImpl.scala
@@ -7,4 +7,7 @@ private final class InboundStreamStateImpl(
 ) extends StreamStateImpl(session)
     with InboundStreamState {
   override def name: String = s"InboundStreamState($streamId)"
+
+  // Inbound streams are always initialized
+  override def initialized: Boolean = true
 }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/OutboundStreamStateImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/OutboundStreamStateImpl.scala
@@ -9,11 +9,12 @@ private abstract class OutboundStreamStateImpl(session: SessionCore)
   private[this] var lazyStreamId: Int = -1
   private[this] var lazyFlowWindow: StreamFlowWindow = null
 
-  private[this] def initialized: Boolean = lazyStreamId != -1
   private[this] def uninitializedException(): Nothing =
     throw new IllegalStateException("Stream uninitialized")
 
   protected def registerStream(): Option[Int]
+
+  final override def initialized: Boolean = lazyStreamId != -1
 
   final override def name: String = {
     val id = if (initialized) Integer.toString(streamId) else "uninitialized"

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamState.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamState.scala
@@ -6,6 +6,14 @@ import org.http4s.blaze.pipeline.HeadStage
 
 private trait StreamState extends HeadStage[StreamFrame] with WriteInterest {
 
+  /** Whether the `StreamState` is part of the H2 session
+    *
+    * This is used by client streams to signal that they haven't yet become
+    * part of the H2 session since they are 'lazy' until they have emitted
+    * the first HEADERS frame, at which point they get assigned a stream id.
+    */
+  def initialized: Boolean
+
   /** Stream ID associated with this stream */
   def streamId: Int
 


### PR DESCRIPTION
Right now, there is no way for a user of a BodyWriter to signal to the
consuming side that it is being closed due to some problem, thus the
other end may think that the stream closed successfully, while in
reality it may be incomplete.

To fix this, we add a `cause: Option[Throwable]` to the `close` method
to allow the data producer to signal that it is closing due to a
problem.