### PR TITLE
tweak sources to compile on JDK 9

### DIFF
--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSpec.scala
@@ -243,7 +243,9 @@ class SSLStageSpec extends Specification {
           assert(handShakeBuffer == null)
           handShakeBuffer = o
 
-        case NEED_UNWRAP => ()
+        // wildcard case includes NEED_UNWRAP, but also NEED_UNWRAP_AGAIN which is new in JDK 9.
+        // need wildcard to be source-compatible and exhaustiveness-warning-free on both 8 and 9
+        case _  => ()
       }
     }
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/FrameDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/FrameDecoder.scala
@@ -41,8 +41,8 @@ private class FrameDecoder(localSettings: Http2Settings, listener: FrameListener
       BufferUnderflow
     } else { // full frame. Decode.
       // set frame sizes in the ByteBuffer and decode
-      val oldLimit = buffer.limit
-      val endOfFrame = buffer.position + len
+      val oldLimit = buffer.limit()
+      val endOfFrame = buffer.position() + len
       buffer.limit(endOfFrame)
 
       try frameType match {
@@ -309,7 +309,7 @@ private object FrameDecoder {
       Error(
         PROTOCOL_ERROR.goaway(s"Padding ($padding) exceeds payload length: ${buffer.remaining}"))
     } else {
-      buffer.limit(buffer.limit - padding)
+      buffer.limit(buffer.limit() - padding)
       Continue
     }
 

--- a/http/src/test/scala/org/http4s/blaze/http/parser/ServerParserSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/parser/ServerParserSpec.scala
@@ -208,7 +208,7 @@ class ServerParserSpec extends Specification {
 
     "need input on partial headers" in {
       val p = new Parser()
-      p.parseHeaders(headers.slice(0, 20)) should_== (false)
+      p.parseHeaders(headers.substring(0, 20)) should_== (false)
       p.parseheaders(headers.substring(20)) should_== (true)
       p.h.result should_== (l_headers.map { case (a, b) => (a.trim, b.trim)})
     }
@@ -324,7 +324,7 @@ class ServerParserSpec extends Specification {
 
       while (!p.contentComplete()) {
         p.parsecontent(b)
-        if (b.limit < blim) b.limit(b.limit() + 1)
+        if (b.limit() < blim) b.limit(b.limit() + 1)
       }
 
       p.contentComplete() should_== (true)
@@ -357,7 +357,7 @@ class ServerParserSpec extends Specification {
 
       while (!p.contentComplete()) {
         p.parsecontent(b)
-        if (b.limit < blim) b.limit(b.limit() + 1)
+        if (b.limit() < blim) b.limit(b.limit() + 1)
       }
       p.h.result should_== (("Foo", "") :: Nil)
       p.contentComplete() should_== (true)


### PR DESCRIPTION
this turned up in the Scala 2.12 community build at https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk9-integrate-community-build/351/consoleFull