### PR TITLE
Add a new end-to-end test

### DIFF
--- a/http/src/test/scala/org/http4s/blaze/http/endtoend/InfiniteSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/endtoend/InfiniteSpec.scala
@@ -1,0 +1,105 @@
+package org.http4s.blaze.http.endtoend
+
+import org.specs2.mutable.Specification
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic._
+import java.util.concurrent.TimeUnit
+
+import org.asynchttpclient._
+
+import org.http4s.blaze.http._
+import org.http4s.blaze.http.endtoend.scaffolds._
+
+import scala.util._
+import scala.concurrent._
+import scala.concurrent.duration._
+
+class InfiniteSpec extends Specification {
+
+  implicit def ec = ExecutionContext.global
+
+  "An infinite server response" should {
+
+    "be properly cleaned on client close" in {
+      val packetSize = 1024
+
+      val bytesSentCount = new AtomicInteger(0)
+      val bytesReceivedCount = new AtomicInteger(0)
+      val lastMessageSentAt = new AtomicLong(-1)
+      val streamInterrupted = new AtomicBoolean(false)
+
+      val client = Dsl.asyncHttpClient()
+
+      val service: HttpService = { request =>
+        request.url match {
+          case "/infinite" => Future.successful {
+            new RouteAction {
+              override def handle[T <: BodyWriter](responder: (HttpResponsePrelude) => T) = {
+                val writer = responder(HttpResponsePrelude(200, "OK", Nil))
+                val p = Promise[T#Finished]
+                def go(): Unit = {
+                  writer.write(StandardCharsets.UTF_8.encode((0 to packetSize).map(_ => 'X').mkString))
+                    .flatMap(_ => writer.flush())
+                    .onComplete {
+                      case Success(_) =>
+                        bytesSentCount.addAndGet(packetSize)
+                        go()
+                      case Failure(e) =>
+                        streamInterrupted.set(true)
+                        p.tryFailure(e)
+                    }
+                }
+                ec.execute(new Runnable { def run(): Unit = go() })
+                p.future
+              }
+            }
+          }
+        }
+      }
+
+      (new Http1ServerScaffold(service)) { address =>
+        val request = new RequestBuilder()
+        request.setMethod("GET")
+        request.setUrl(s"http://localhost:${address.getPort}/infinite")
+
+        // Interrupt this request client side after we received 10MB
+        val completed =
+          client.executeRequest(request, new AsyncHandler[Boolean] {
+            override def onStatusReceived(status: HttpResponseStatus) = {
+              require(status.getStatusCode == 200)
+              AsyncHandler.State.CONTINUE
+            }
+            override def onBodyPartReceived(part: HttpResponseBodyPart) = {
+              if(bytesReceivedCount.addAndGet(part.length) < (packetSize * 10))
+                AsyncHandler.State.CONTINUE
+              else
+                AsyncHandler.State.ABORT
+            }
+            override def onHeadersReceived(headers: HttpResponseHeaders) = {
+              require(headers.getHeaders.get("transfer-encoding") == "chunked")
+              require(headers.getHeaders.get("content-length") == null)
+              AsyncHandler.State.CONTINUE
+            }
+            override def onThrowable(e: Throwable) = ()
+            override def onCompleted() = true
+          }).toCompletableFuture.get(10, TimeUnit.SECONDS)
+        client.close()
+
+        completed must beTrue
+
+        // Assert that eventually, the server noticed that the client was gone and
+        // properly cleaned its resources
+        eventually {
+          streamInterrupted.get must beTrue
+          (System.currentTimeMillis - lastMessageSentAt.get) must beGreaterThanOrEqualTo(1000.toLong)
+        }
+
+        bytesReceivedCount.get must beGreaterThanOrEqualTo(packetSize * 10)
+        bytesSentCount.get must beGreaterThanOrEqualTo(packetSize * 10)
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
While tracking a bug with infinite server side response streams  and disconnected clients I came up with this new test. At the end the test demonstrated that there was no issue in Blaze, but I think it can still be useful to have it to avoid any future regression.