### PR TITLE
Release v0.14.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import BlazePlugin._
 organization in ThisBuild := "org.http4s"
 
 lazy val commonSettings = Seq(
-  version := "0.14.0-M3",
+  version := "0.14.0-M4",
   description := "NIO Framework for Scala",
   crossScalaVersions := Seq("2.11.11", scalaVersion.value),
   scalacOptions in (Compile, doc) ++= Seq("-no-link-warnings") // Suppresses problems with Scaladoc @throws links

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -63,6 +63,7 @@ sealed trait Stage {
     */
   def inboundCommand(cmd: InboundCommand): Unit = cmd match {
     case Connected => stageStartup()
+    case Disconnected => logger.debug("Received Disconnected command")
     case _ => logger.warn(s"$name received unhandled inbound command: $cmd")
   }
 }

--- a/project/BlazePlugin.scala
+++ b/project/BlazePlugin.scala
@@ -93,18 +93,18 @@ object BlazePlugin extends AutoPlugin {
 
   lazy val logbackClassic      = "ch.qos.logback"             %  "logback-classic"     % "1.2.3"
   lazy val twitterHPACK        = "com.twitter"                %  "hpack"               % "1.0.2"
-  lazy val asyncHttpClient     = "org.asynchttpclient"        %  "async-http-client"   % "2.0.37"
-  lazy val http4sWebsocket     = "org.http4s"                 %% "http4s-websocket"    % "0.2.0"
-  lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"           % "1.0.6"
-  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.4.0"
-  lazy val scalacheck          = "org.scalacheck"             %% "scalacheck"          % "1.13.5"
-  lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "3.8.9"
+  lazy val asyncHttpClient     = "org.asynchttpclient"        %  "async-http-client"   % "2.5.2"
+  lazy val http4sWebsocket     = "org.http4s"                 %% "http4s-websocket"    % "0.2.1"
+  lazy val scalaXml            = "org.scala-lang.modules"     %% "scala-xml"           % "1.1.0"
+  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.6.1"
+  lazy val scalacheck          = "org.scalacheck"             %% "scalacheck"          % "1.14.0"
+  lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "4.3.4"
   lazy val specs2Mock          = "org.specs2"                 %% "specs2-mock"         % specs2.revision
   lazy val specs2Scalacheck    = "org.specs2"                 %% "specs2-scalacheck"   % specs2.revision
   // Needed for Http2 support until implemented in the JDK
   lazy val alpn_api            = "org.eclipse.jetty.alpn"     % "alpn-api"             % "1.1.3.v20160715"
   // Note that the alpn_boot version is JVM version specific. Check the docs if getting weird errors.
   // Also note that only java8 and above has the require cipher suite for http2.
-  lazy val alpn_boot           = "org.mortbay.jetty.alpn"     % "alpn-boot"            % "8.1.11.v20170118"
+  lazy val alpn_boot           = "org.mortbay.jetty.alpn"     % "alpn-boot"            % "8.1.12.v20180117"
 
 }


### PR DESCRIPTION
Proposing this intermediate release to unblock http4s milestone.

Fixes #218 by quieting `Disconnected` events.  These are not handled by `Http1ServerStage`, `QuietTimeoutStage`, `SSLStage`, which causes at least 2 warnings on every request, 3 if SSL.  HTTP/2 and websockets are probably also affected.  Maybe we ignore these at our own peril.

Catching up to the demise of `OutboundCommand` is left for https://github.com/http4s/http4s/issues/2058, but we need a milestone now.

Backported #216 in order to avoid dependency warnings on log4s.

This should be merged back to master after release.