### PR TITLE
Refactor TimeoutStage

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStage.scala
@@ -1,23 +1,24 @@
 package org.http4s.blaze.pipeline.stages
 
 import org.http4s.blaze.util.Execution._
-import org.http4s.blaze.util.TickWheelExecutor
-
+import org.http4s.blaze.util.{Cancelable, TickWheelExecutor}
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.util.{Success, Try}
 
 /** Shut down the pipeline after a period of inactivity */
-class QuietTimeoutStage[T](timeout: FiniteDuration, exec: TickWheelExecutor = scheduler)
-    extends TimeoutStageBase[T](timeout, exec) {
+trait QuietTimeoutStage[A] extends TimeoutStage[A, A] {
+
+  def name = "QuietTimeoutStage"
 
   ////////////////////////////////////////////////////////////////////////////////
 
-  override protected def stageStartup(): Unit = {
+  final override protected def stageStartup(): Unit = {
     super.stageStartup()
     startTimeout()
   }
 
-  override def readRequest(size: Int): Future[T] = {
+  final override def readRequest(size: Int): Future[A] = {
     val f = channelRead(size)
     f.onComplete { _ =>
       resetTimeout()
@@ -25,7 +26,7 @@ class QuietTimeoutStage[T](timeout: FiniteDuration, exec: TickWheelExecutor = sc
     f
   }
 
-  override def writeRequest(data: Seq[T]): Future[Unit] = {
+  final override def writeRequest(data: Seq[A]): Future[Unit] = {
     val f = channelWrite(data)
     f.onComplete { _ =>
       resetTimeout()
@@ -33,11 +34,25 @@ class QuietTimeoutStage[T](timeout: FiniteDuration, exec: TickWheelExecutor = sc
     f
   }
 
-  override def writeRequest(data: T): Future[Unit] = {
+  final override def writeRequest(data: A): Future[Unit] = {
     val f = channelWrite(data)
     f.onComplete { _ =>
       resetTimeout()
     }(directec)
     f
   }
+}
+
+object QuietTimeoutStage {
+  private val SuccessUnit = Success(())
+
+  def apply[A](timeout: FiniteDuration, tickWheelExecutor: TickWheelExecutor): QuietTimeoutStage[A] =
+    new QuietTimeoutStage[A] {
+      protected def scheduleTimeout(cb: Try[Unit] => Unit): Cancelable = {
+        val r = new Runnable {
+          def run() = cb(SuccessUnit)
+        }
+        tickWheelExecutor.schedule(r, timeout)
+      }
+    }
 }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStage.scala
@@ -4,10 +4,10 @@ import org.http4s.blaze.util.Execution._
 import org.http4s.blaze.util.TickWheelExecutor
 
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 /** Shut down the pipeline after a period of inactivity */
-class QuietTimeoutStage[T](timeout: Duration, exec: TickWheelExecutor = scheduler)
+class QuietTimeoutStage[T](timeout: FiniteDuration, exec: TickWheelExecutor = scheduler)
     extends TimeoutStageBase[T](timeout, exec) {
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/TimeoutStageBase.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/TimeoutStageBase.scala
@@ -4,19 +4,16 @@ package stages
 import java.util.concurrent.TimeoutException
 import scala.annotation.tailrec
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 import org.http4s.blaze.pipeline.Command.InboundCommand
 import org.http4s.blaze.util.{Cancellable, TickWheelExecutor}
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.duration.Duration
 
-abstract class TimeoutStageBase[T](timeout: Duration, exec: TickWheelExecutor)
+abstract class TimeoutStageBase[T](timeout: FiniteDuration, exec: TickWheelExecutor)
     extends MidStage[T, T] { stage =>
 
   import TimeoutStageBase.closedTag
-
-  // Constructor
-  require(timeout.isFinite() && timeout.toMillis != 0, s"Invalid timeout: $timeout")
 
   override def name: String = s"${this.getClass.getName} Stage: $timeout"
 

--- a/core/src/main/scala/org/http4s/blaze/util/Cancelable.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/Cancelable.scala
@@ -1,17 +1,17 @@
 package org.http4s.blaze.util
 
-object Cancellable {
+object Cancelable {
 
-  /** Cancellable which does nothing */
-  val NoopCancel = new Cancellable {
+  /** Cancelable which does nothing */
+  val NoopCancel = new Cancelable {
     def cancel(): Unit = ()
   }
 }
 
 /** Type that can be canceled. */
-trait Cancellable {
+trait Cancelable {
 
-  /** Attempt to cancel this `Cancellable`.
+  /** Attempt to cancel this `Cancelable`.
     *
     * Cancellation is not guaranteed.
     */

--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -75,7 +75,7 @@ class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, tick: Duration = 200.
     * @return a [[Cancellable]]. This is not a `java.util.concurrent.Cancellable`,
     *         which is a richer interface.
     */
-  def schedule(r: Runnable, timeout: Duration): Cancellable =
+  def schedule(r: Runnable, timeout: Duration): Cancelable =
     schedule(r, Execution.directec, timeout)
 
   /** Schedule the `Runnable` on the [[TickWheelExecutor]]
@@ -89,10 +89,10 @@ class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, tick: Duration = 200.
     * @return a [[Cancellable]]. This is not a `java.util.concurrent.Cancellable`,
     *         which is a richer interface.
     */
-  def schedule(r: Runnable, ec: ExecutionContext, timeout: Duration): Cancellable =
+  def schedule(r: Runnable, ec: ExecutionContext, timeout: Duration): Cancelable =
     if (alive) {
       if (!timeout.isFinite) { // This will never timeout, so don't schedule it.
-        Cancellable.NoopCancel
+        Cancelable.NoopCancel
       } else {
         val millis = timeout.toMillis
         if (millis > 0) {
@@ -110,7 +110,7 @@ class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, tick: Duration = 200.
         } else { // we can submit the task right now! Not sure why you would want to do this...
           try ec.execute(r)
           catch { case NonFatal(t) => onNonFatal(t) }
-          Cancellable.NoopCancel
+          Cancelable.NoopCancel
         }
       }
     } else sys.error("TickWheelExecutor is shutdown")
@@ -217,7 +217,7 @@ class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, tick: Duration = 200.
       var prev: Node,
       var next: Node,
       var canceled: Boolean = false
-  ) extends Cancellable {
+  ) extends Cancelable {
 
     /** Remove this node from its linked list */
     def unlink(): Unit = {

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -1,7 +1,7 @@
-package org.http4s.blaze.pipeline.stages
+package org.http4s.blaze.pipeline
+package stages
 
 import java.nio.ByteBuffer
-import org.http4s.blaze.pipeline.Command
 import scala.concurrent.duration._
 
 class QuietTimeoutStageSpec extends TimeoutHelpers {
@@ -20,25 +20,19 @@ class QuietTimeoutStageSpec extends TimeoutHelpers {
     "timeout properly" in {
       val pipe = makePipeline(delay = 10.seconds, timeout = 100.milliseconds)
       checkFuture(pipe.channelRead(), 5.second) should throwA[Command.EOF.type]
-      pipe.inboundCommandsReceived.get must contain(TimeoutStageBase.TimedOut(100.milliseconds))
-    }
-
-    "not timeout if the delay stage is removed" in {
-      val pipe = makePipeline(2.seconds, 1.second)
-      val f = pipe.channelRead()
-      pipe.findOutboundStage(classOf[TimeoutStageBase[ByteBuffer]]).get.removeStage
-      checkFuture(f, 5.second)
-      pipe.closePipeline(None)
-      pipe.inboundCommandsReceived.get must not contain(TimeoutStageBase.TimedOut(1.second))
+      isTimedOut(pipe) must beTrue
     }
 
     "not schedule timeouts after the pipeline has been shut down" in {
       val pipe = makePipeline(delay = 10.seconds, timeout = 1.second)
       val f = pipe.channelRead()
       pipe.closePipeline(None)
-
       checkFuture(f, 5.second) should throwA[Command.EOF.type]
-      pipe.inboundCommandsReceived.get must not contain(TimeoutStageBase.TimedOut(1.second))
+      isTimedOut(pipe) must beFalse
     }
+  }
+
+  private def isTimedOut[A](pipe: Tail[A]) = {
+    pipe.findOutboundStage(classOf[QuietTimeoutStage[_]]).get.timedOut.value.isDefined
   }
 }

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -1,14 +1,12 @@
 package org.http4s.blaze.pipeline.stages
 
 import java.nio.ByteBuffer
-
 import org.http4s.blaze.pipeline.Command
-
 import scala.concurrent.duration._
 
 class QuietTimeoutStageSpec extends TimeoutHelpers {
 
-  override def genDelayStage(timeout: Duration): TimeoutStageBase[ByteBuffer] = new QuietTimeoutStage[ByteBuffer](timeout)
+  override def genDelayStage(timeout: FiniteDuration): TimeoutStageBase[ByteBuffer] = new QuietTimeoutStage[ByteBuffer](timeout)
 
   "A QuietTimeoutStage" should {
     "not timeout with propper intervals" in {

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -2,11 +2,19 @@ package org.http4s.blaze.pipeline
 package stages
 
 import java.nio.ByteBuffer
+import org.http4s.blaze.util.TickWheelExecutor
+import org.specs2.specification.BeforeAfterAll
 import scala.concurrent.duration._
 
-class QuietTimeoutStageSpec extends TimeoutHelpers {
+class QuietTimeoutStageSpec extends TimeoutHelpers with BeforeAfterAll {
 
-  override def genDelayStage(timeout: FiniteDuration): TimeoutStageBase[ByteBuffer] = new QuietTimeoutStage[ByteBuffer](timeout)
+  var scheduler: TickWheelExecutor = null
+
+  override def beforeAll() = { scheduler = new TickWheelExecutor() }
+  override def afterAll() = scheduler.shutdown()
+
+  override def genDelayStage(timeout: FiniteDuration): TimeoutStage[String, String] =
+    QuietTimeoutStage[String](timeout, scheduler)
 
   "A QuietTimeoutStage" should {
     "not timeout with propper intervals" in {

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/TimeoutHelpers.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/TimeoutHelpers.scala
@@ -29,7 +29,7 @@ abstract class TimeoutHelpers extends Specification {
     }
   }
   
-  def genDelayStage(timeout: Duration): TimeoutStageBase[ByteBuffer]
+  def genDelayStage(timeout: FiniteDuration): TimeoutStageBase[ByteBuffer]
 
   def newBuff: ByteBuffer = ByteBuffer.wrap("Foo".getBytes(StandardCharsets.UTF_8))
 
@@ -45,7 +45,7 @@ abstract class TimeoutHelpers extends Specification {
   def slow(duration: Duration): DelayHead[ByteBuffer] =
     new DelayHead[ByteBuffer](duration) { def next() = newBuff }
 
-  def makePipeline(delay: Duration, timeout: Duration): TimeoutTail[ByteBuffer] = {
+  def makePipeline(delay: Duration, timeout: FiniteDuration): TimeoutTail[ByteBuffer] = {
     val leaf = new TimeoutTail[ByteBuffer]("TestTail")
     val head = slow(delay)
     LeafBuilder(leaf)


### PR DESCRIPTION
Instead of closing the pipeline with an exception on timeout, send an inbound command.  This will let an HTTP-aware stage return a 503 if the response is not yet committed.

```scala
[info] [blaze-selector-0-1] ERROR o.h.b.c.n.NIO1HeadStage - Abnormal NIO1HeadStage termination 
[info] java.util.concurrent.TimeoutException: Timeout of 30 seconds triggered. Killing pipeline.
[info] at org.http4s.blaze.pipeline.stages.TimeoutStageBase$$anon$1.run(TimeoutStageBase.scala:29)
[info] at org.http4s.blaze.util.Execution$$anon$3.execute(Execution.scala:66) 
[info] at org.http4s.blaze.util.TickWheelExecutor$Node.run(TickWheelExecutor.scala:261)
[info] at org.http4s.blaze.util.TickWheelExecutor$Bucket.checkNext$1(TickWheelExecutor.scala:193
[info] at org.http4s.blaze.util.TickWheelExecutor$Bucket.prune(TickWheelExecutor.scala:200)
[info] at org.http4s.blaze.util.TickWheelExecutor.go$3(TickWheelExecutor.scala:153)
[info] at org.http4s.blaze.util.TickWheelExecutor.org$http4s$blaze$util$TickWheelExecutor$$cycle(TickWheelExecutor.scala:156) 
[info] at org.http4s.blaze.util.TickWheelExecutor$$anon$1.run(TickWheelExecutor.scala:55)
[info] [blaze-selector-0-1] ERROR o.h.s.b.Http1ServerStage$$anon$1 - Fatal Error: Error in requestLoop()
[info] java.util.concurrent.TimeoutException: Timeout of 30 seconds triggered. Killing pipeline.
```
