### PR TITLE
Don't warn on the removal of a disconnected MidStage

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -345,12 +345,15 @@ trait MidStage[I, O] extends Tail[I] with Head[O] {
     stageShutdown()
 
     if (_prevStage != null && _nextStage != null) {
+      logger.debug(s"Removed mid-stage: ${name}")
       val me: MidStage[I, I] = ev(this)
       _prevStage._nextStage = me._nextStage
       me._nextStage._prevStage = me._prevStage
 
       _nextStage = null
       _prevStage = null
+    } else {
+      logger.debug(s"Attempted to remove a disconnected mid-stage: ${name}")
     }
   }
 }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -351,7 +351,6 @@ trait MidStage[I, O] extends Tail[I] with Head[O] {
 
       _nextStage = null
       _prevStage = null
-    } else
-      logger.warn(s"Cannot remove a disconnected stage ${this.getClass.getSimpleName}")
+    }
   }
 }


### PR DESCRIPTION
It's idempotent, and so is stage shutdown. No reason to scare people in the logs.