### PR TITLE
Handle exceptions handling client channels

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1SocketServerGroup.scala
@@ -259,7 +259,7 @@ private final class NIO1SocketServerGroup private (
   private[this] def handleClientChannel(
       clientChannel: SocketChannel,
       service: SocketPipelineBuilder
-  ): Unit = {
+  ): Unit = try {
     clientChannel.configureBlocking(false)
     channelOptions.applyToChannel(clientChannel)
 
@@ -287,5 +287,14 @@ private final class NIO1SocketServerGroup private (
     }
 
     loop.initChannel(NIO1Channel(clientChannel), fromKey)
+  }
+  catch {
+    case NonFatal(t) =>
+      logger.error(t)("Error handling client channel. Closing.")
+      try clientChannel.close()
+      catch {
+        case NonFatal(t2) =>
+          logger.error(t2)("Error closing client channel after error")
+      }
   }
 }


### PR DESCRIPTION
@SebastianVoss [reports](https://gitter.im/http4s/http4s?at=5bd8a75d600c5f6423313cbd) this error:

```
project examples-blaze
runMain com.example.http4s.blaze.BlazeSslExample
# http --verify=no https://localhost:8443/http4s <-- works many times
# nmap --script ssl-enum-ciphers -p 8443 localhost <-- crashes the server
```

```
 19:41:53.274 [blaze-selector-0-1] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Accepted connection from /127.0.0.1:58481
 19:42:02.796 [blaze-selector-0-0] ERROR o.h.b.c.nio1.NIO1SocketServerGroup - Listening socket(/127.0.0.1:8443) closed forcibly.
 java.net.SocketException: Invalid argument
     at sun.nio.ch.Net.setIntOption0(Native Method)
     at sun.nio.ch.Net.setSocketOption(Net.java:334)
     at sun.nio.ch.SocketChannelImpl.setOption(SocketChannelImpl.java:190)
     at sun.nio.ch.SocketChannelImpl.setOption(SocketChannelImpl.java:43)
     at org.http4s.blaze.channel.ChannelOptions.$anonfun$applyToChannel$1(ChannelOptions.scala:12)
     at scala.collection.Iterator.foreach(Iterator.scala:937)
     at scala.collection.Iterator.foreach$(Iterator.scala:937)
     at scala.collection.AbstractIterator.foreach(Iterator.scala:1425)
     at scala.collection.IterableLike.foreach(IterableLike.scala:70)
     at scala.collection.IterableLike.foreach$(IterableLike.scala:69)
     at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
     at org.http4s.blaze.channel.ChannelOptions.applyToChannel(ChannelOptions.scala:12)
     at org.http4s.blaze.channel.nio1.NIO1SocketServerGroup.org$http4s$blaze$channel$nio1$NIO1SocketServerGroup$$handleClientChannel(NIO1SocketServerGroup.scala:264)
     at org.http4s.blaze.channel.nio1.NIO1SocketServerGroup$SocketAcceptor.acceptNewConnections(NIO1SocketServerGroup.scala:148)
     at org.http4s.blaze.channel.nio1.NIO1SocketServerGroup$SocketAcceptor.opsReady(NIO1SocketServerGroup.scala:119)
     at org.http4s.blaze.channel.nio1.SelectorLoop.processKeys(SelectorLoop.scala:198)
     at org.http4s.blaze.channel.nio1.SelectorLoop.org$http4s$blaze$channel$nio1$SelectorLoop$$runLoop(SelectorLoop.scala:169)
     at org.http4s.blaze.channel.nio1.SelectorLoop$$anon$1.run(SelectorLoop.scala:67)
     at java.lang.Thread.run(Thread.java:748)
 19:42:02.797 [blaze-selector-0-0] INFO  o.http4s.blaze.channel.ServerChannel - Closing NIO1 channel /127.0.0.1:8443
```

I can't reproduce it, but this should keep the server alive if it happens.