### PR TITLE
Handshake status can change to FINISHED, even if wrap produced no data.

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -183,9 +183,10 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
         case HandshakeStatus.NEED_WRAP =>
           val o = getScratchBuffer(maxBuffer)
           val r = engine.wrap(emptyBuffer, o)
+          logger.trace(s"SSL Handshake Status after wrap: $r")
           o.flip()
 
-          if (r.bytesProduced < 1)
+          if (r.bytesProduced < 1 && r.getHandshakeStatus != HandshakeStatus.FINISHED)
             handshakeFailure(new SSLException(s"SSL Handshake WRAP produced 0 bytes: $r"))
 
           channelWrite(copyBuffer(o)).onComplete {


### PR DESCRIPTION
Should fix https://github.com/http4s/blaze/issues/258