### PR TITLE
SSL Engine cleanup

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -61,9 +61,10 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
       engine.closeInbound()
       engine.closeOutbound()
     } catch {
-      case _: SSLException =>
-      //Ignore cleanup errors. Example: With JDK SSLContextImpl, if the connection is closed before even handshake
-      //began(like port scanning), an SSLException might be thrown.
+      case e: SSLException =>
+        //Ignore cleanup errors. Example: With JDK SSLContextImpl, if the connection is closed before even handshake
+        //began(like port scanning), an SSLException might be thrown.
+        logger.debug(e)("Error while closing SSL Engine")
     }
 
   private[this] val maxNetSize = engine.getSession.getPacketBufferSize

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -56,6 +56,11 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
 
   }
 
+  override protected def stageShutdown(): Unit = {
+    engine.closeInbound()
+    engine.closeOutbound()
+  }
+
   private[this] val maxNetSize = engine.getSession.getPacketBufferSize
   private[this] val maxBuffer = math.max(maxNetSize, engine.getSession.getApplicationBufferSize)
 

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -61,7 +61,7 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
       engine.closeInbound()
       engine.closeOutbound()
     } catch {
-      case _: Throwable =>
+      case _: SSLException =>
       //Ignore cleanup errors. Example: With JDK SSLContextImpl, if the connection is closed before even handshake
       //began(like port scanning), an SSLException might be thrown.
     }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -56,10 +56,15 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
 
   }
 
-  override protected def stageShutdown(): Unit = {
-    engine.closeInbound()
-    engine.closeOutbound()
-  }
+  override protected def stageShutdown(): Unit =
+    try {
+      engine.closeInbound()
+      engine.closeOutbound()
+    } catch {
+      case _: Throwable =>
+      //Ignore cleanup errors. Example: With JDK SSLContextImpl, if the connection is closed before even handshake
+      //began(like port scanning), an SSLException might be thrown.
+    }
 
   private[this] val maxNetSize = engine.getSession.getPacketBufferSize
   private[this] val maxBuffer = math.max(maxNetSize, engine.getSession.getApplicationBufferSize)


### PR DESCRIPTION
Cleanup SSL Engine during connection close. 

With JDK SSLContext, this is not required. With native ssl context(Ex: conscrypt), calling close() methods frees up native memory associated with each connection. Otherwise, system will leak memory for every connection.