### PR TITLE
Implement connecting timeout in ClientChannelFactory.

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
@@ -27,6 +27,13 @@ final class ClientChannelFactory(
     scheduler: TickWheelExecutor = Execution.scheduler,
     connectingTimeout: Option[FiniteDuration] = None) {
 
+  // for binary compatibility with <=0.14.6
+  def this(
+      bufferSize: Int,
+      group: Option[AsynchronousChannelGroup],
+      channelOptions: ChannelOptions) =
+    this(bufferSize, group, channelOptions, Execution.scheduler, None)
+
   def connect(
       remoteAddress: SocketAddress,
       bufferSize: Int = bufferSize): Future[HeadStage[ByteBuffer]] = {

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
@@ -25,7 +25,7 @@ final class ClientChannelFactory(
     group: Option[AsynchronousChannelGroup] = None,
     channelOptions: ChannelOptions = ChannelOptions.DefaultOptions,
     scheduler: TickWheelExecutor = Execution.scheduler,
-    connectingTimeout: Duration = Duration.Inf) {
+    connectTimeout: Duration = Duration.Inf) {
 
   // for binary compatibility with <=0.14.6
   def this(
@@ -42,12 +42,12 @@ final class ClientChannelFactory(
     try {
       val ch = AsynchronousSocketChannel.open(group.orNull)
 
-      val scheduledTimeout = connectingTimeout match {
+      val scheduledTimeout = connectTimeout match {
         case d: FiniteDuration =>
           val onTimeout = new Runnable {
             override def run(): Unit = {
               val exception = new SocketTimeoutException(
-                s"An attempt to establish connection with $remoteAddress timed out after $connectingTimeout.")
+                s"An attempt to establish connection with $remoteAddress timed out after $connectTimeout.")
               val finishedWithTimeout = p.tryFailure(exception)
               if (finishedWithTimeout) {
                 try { ch.close() } catch { case NonFatal(_) => /* we don't care */ }

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
@@ -43,10 +43,12 @@ final class ClientChannelFactory(
       val ch = AsynchronousSocketChannel.open(group.orNull)
 
       val scheduledTimeout = connectingTimeout.map { t =>
-        val onTimeout: Runnable = () => {
-          val finishedWithTimeout = p.tryFailure(new SocketTimeoutException())
-          if (finishedWithTimeout) {
-            try { ch.close() } catch { case NonFatal(_) => /* we don't care */ }
+        val onTimeout = new Runnable {
+          override def run(): Unit = {
+            val finishedWithTimeout = p.tryFailure(new SocketTimeoutException())
+            if (finishedWithTimeout) {
+              try { ch.close() } catch { case NonFatal(_) => /* we don't care */ }
+            }
           }
         }
         scheduler.schedule(onTimeout, t)

--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -23,7 +23,7 @@ import org.log4s.getLogger
   * @param wheelSize number of spokes on the wheel. Each tick, the wheel will advance a spoke
   * @param tick duration between ticks
   */
-class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, tick: Duration = 200.milli) {
+class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, val tick: Duration = 200.milli) {
 
   require(wheelSize > 0, "Need finite size number of ticks")
   require(tick.isFinite && tick.toNanos != 0, "tick duration must be finite")

--- a/core/src/test/scala/org/http4s/blaze/channel/nio2/ClientChannelFactorySpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/nio2/ClientChannelFactorySpec.scala
@@ -13,7 +13,7 @@ class ClientChannelFactorySpec extends Specification {
   "ClientChannelFactory" should {
     "time out" in new FastTickWheelExecutor {
       val factory =
-        new ClientChannelFactory(connectingTimeout = 1.millisecond, scheduler = scheduler)
+        new ClientChannelFactory(connectTimeout = 1.millisecond, scheduler = scheduler)
       val address = new InetSocketAddress("192.0.2.0", 1) // rfc5737 TEST-NET-1
 
       Await.result(factory.connect(address), 500.milliseconds) should throwA[SocketTimeoutException]

--- a/core/src/test/scala/org/http4s/blaze/channel/nio2/ClientChannelFactorySpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/nio2/ClientChannelFactorySpec.scala
@@ -2,8 +2,8 @@ package org.http4s.blaze.channel.nio2
 
 import java.net.{InetSocketAddress, SocketTimeoutException}
 
-import org.http4s.blaze.util.TickWheelExecutor
-import org.specs2.mutable.{After, Specification}
+import org.http4s.blaze.test.FastTickWheelExecutor
+import org.specs2.mutable.Specification
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationDouble
@@ -11,22 +11,12 @@ import scala.concurrent.duration.DurationDouble
 class ClientChannelFactorySpec extends Specification {
 
   "ClientChannelFactory" should {
-    "time out" in new fastTickWheelExecutor {
+    "time out" in new FastTickWheelExecutor {
       val factory =
-        new ClientChannelFactory(connectingTimeout = Some(1.millisecond), scheduler = scheduler)
-      val address = new InetSocketAddress("1.1.1.1", 1)
+        new ClientChannelFactory(connectingTimeout = 1.millisecond, scheduler = scheduler)
+      val address = new InetSocketAddress("192.0.2.0", 1) // rfc5737 TEST-NET-1
 
       Await.result(factory.connect(address), 500.milliseconds) should throwA[SocketTimeoutException]
     }
-  }
-}
-
-trait fastTickWheelExecutor extends After {
-  // The default TickWheelExecutor has 200ms ticks. It should be acceptable for most real world use cases.
-  // If one needs very short timeouts (like we do in tests), providing a custom TickWheelExecutor is a solution.
-  val scheduler: TickWheelExecutor = new TickWheelExecutor(tick = 10.millis)
-  def after: Unit = {
-    scheduler.shutdown()
-    ()
   }
 }

--- a/core/src/test/scala/org/http4s/blaze/channel/nio2/ClientChannelFactorySpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/nio2/ClientChannelFactorySpec.scala
@@ -1,0 +1,32 @@
+package org.http4s.blaze.channel.nio2
+
+import java.net.{InetSocketAddress, SocketTimeoutException}
+
+import org.http4s.blaze.util.TickWheelExecutor
+import org.specs2.mutable.{After, Specification}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationDouble
+
+class ClientChannelFactorySpec extends Specification {
+
+  "ClientChannelFactory" should {
+    "time out" in new fastTickWheelExecutor {
+      val factory =
+        new ClientChannelFactory(connectingTimeout = Some(1.millisecond), scheduler = scheduler)
+      val address = new InetSocketAddress("1.1.1.1", 1)
+
+      Await.result(factory.connect(address), 500.milliseconds) should throwA[SocketTimeoutException]
+    }
+  }
+}
+
+trait fastTickWheelExecutor extends After {
+  // The default TickWheelExecutor has 200ms ticks. It should be acceptable for most real world use cases.
+  // If one needs very short timeouts (like we do in tests), providing a custom TickWheelExecutor is a solution.
+  val scheduler: TickWheelExecutor = new TickWheelExecutor(tick = 10.millis)
+  def after: Unit = {
+    scheduler.shutdown()
+    ()
+  }
+}

--- a/core/src/test/scala/org/http4s/blaze/test/FastTickWheelExecutor.scala
+++ b/core/src/test/scala/org/http4s/blaze/test/FastTickWheelExecutor.scala
@@ -1,0 +1,15 @@
+package org.http4s.blaze.test
+import org.http4s.blaze.util.TickWheelExecutor
+import org.specs2.mutable.After
+
+import scala.concurrent.duration.DurationLong
+
+trait FastTickWheelExecutor extends After {
+  // The default TickWheelExecutor has 200ms ticks. It should be acceptable for most real world use cases.
+  // If one needs very short timeouts (like we do in tests), providing a custom TickWheelExecutor is a solution.
+  val scheduler: TickWheelExecutor = new TickWheelExecutor(tick = 10.millis)
+  def after: Unit = {
+    scheduler.shutdown()
+    ()
+  }
+}


### PR DESCRIPTION
This PR is motivated by repeating issues around connecting timeouts in http4s:
- https://github.com/http4s/http4s/issues/2386
- https://github.com/http4s/http4s/issues/2338
- https://github.com/http4s/http4s/issues/2690

The current state of connecting timeouts in http4s is that a timeout should happen eventually, but **when** it will happen is up to the OS. For example I've measured 15 seconds on Windows 7 and 135 seconds on Ubuntu 16.04, and @kamilkloch  (https://github.com/http4s/http4s/issues/2690) reports that in his environment the timeout doesn't happen at all. 

For comparison other http client libraries let users configure the timeout: 
- [`akka-http`](https://github.com/akka/akka-http/blob/eb7311130021c6fa72dff05090c20568ee1319dd/akka-http-core/src/main/resources/reference.conf#L256),
- [`sttp`](https://github.com/softwaremill/sttp/blob/cfc757f7449e992aac39af883cbdc0c7e22004a0/docs/conf/timeouts.rst#L6)

Establishing connections is responsibility of `ClientChannelFactory`, so that's where I start the work. I plan to follow up with a PR to http4s, bringing the timeout configuration to the surface of `BlazeClientBuilder`.

