### PR TITLE
Add trailing CRLF to chunks in ChunkedTransferEncoder

### DIFF
--- a/http/src/main/scala/org/http4s/blaze/http/http1/client/Http1BodyEncoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http1/client/Http1BodyEncoder.scala
@@ -28,7 +28,7 @@ private[client] object Http1BodyEncoder {
     override def encode(buffer: ByteBuffer): Seq[ByteBuffer] = {
       val len = buffer.remaining()
       if (len == 0) Nil
-      else ImmutableArray(Array(getLengthBuffer(len), buffer))
+      else ImmutableArray(Array(getLengthBuffer(len), buffer, crlf.duplicate()))
     }
 
     private def getLengthBuffer(length: Int): ByteBuffer = {
@@ -44,6 +44,10 @@ private[client] object Http1BodyEncoder {
       buffer
     }
 
+    private val crlf =
+      ByteBuffer
+        .wrap("\r\n".getBytes(StandardCharsets.UTF_8))
+        .asReadOnlyBuffer()
     private val terminator =
       ByteBuffer
         .wrap("0\r\n\r\n".getBytes(StandardCharsets.UTF_8))

--- a/http/src/test/scala/org/http4s/blaze/http/http1/client/Http1ClientStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http1/client/Http1ClientStageSpec.scala
@@ -189,7 +189,7 @@ class Http1ClientStageSpec extends Specification {
       )
 
       tail.status must_== HttpClientSession.Busy
-      head.consumeWrite() must beSome("3\r\nfoo")
+      head.consumeWrite() must beSome("3\r\nfoo\r\n")
       head.consumeWrite() must beSome("0\r\n\r\n")
       tail.status must_== HttpClientSession.Busy // Haven't sent a response
       head.offerInbound(
@@ -211,7 +211,7 @@ class Http1ClientStageSpec extends Specification {
       )
 
       tail.status must_== HttpClientSession.Busy
-      head.consumeWrite() must beSome("3\r\nfoo")
+      head.consumeWrite() must beSome("3\r\nfoo\r\n")
       head.consumeWrite() must beSome("0\r\n\r\n")
       tail.status must_== HttpClientSession.Busy // Haven't sent a response
       head.offerInbound(


### PR DESCRIPTION
As per the [RFC](https://tools.ietf.org/html/rfc7230#section-4.1). Found it when I was trying to connect blaze `HttpClient` to a http4s server.

Please release a new version with this fix.