### PR TITLE
Reformat Java

### DIFF
--- a/http/src/main/java/org/http4s/blaze/http/parser/BaseExceptions.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/BaseExceptions.java
@@ -2,35 +2,35 @@ package org.http4s.blaze.http.parser;
 
 public class BaseExceptions {
 
-    public static abstract class ParserException extends Exception {
-        private static final long serialVersionUID = 8132184654773444925L;
+  public abstract static class ParserException extends Exception {
+    private static final long serialVersionUID = 8132184654773444925L;
 
-        public ParserException(String msg) {
-            super(msg);
-        }
+    public ParserException(String msg) {
+      super(msg);
     }
+  }
 
-    public static class BadMessage extends ParserException {
-        private static final long serialVersionUID = -6447645402380938086L;
+  public static class BadMessage extends ParserException {
+    private static final long serialVersionUID = -6447645402380938086L;
 
-        public BadMessage(String msg) {
-            super(msg);
-        }
+    public BadMessage(String msg) {
+      super(msg);
     }
+  }
 
-    public static class BadCharacter extends BadMessage {
-        private static final long serialVersionUID = -6336838845289468590L;
+  public static class BadCharacter extends BadMessage {
+    private static final long serialVersionUID = -6336838845289468590L;
 
-        public BadCharacter(String msg) {
-            super(msg);
-        }
+    public BadCharacter(String msg) {
+      super(msg);
     }
+  }
 
-    public static class InvalidState extends ParserException {
-        private static final long serialVersionUID = -1803189728615965013L;
+  public static class InvalidState extends ParserException {
+    private static final long serialVersionUID = -1803189728615965013L;
 
-        public InvalidState(String msg) {
-            super(msg);
-        }
+    public InvalidState(String msg) {
+      super(msg);
     }
+  }
 }

--- a/http/src/main/java/org/http4s/blaze/http/parser/BaseExceptions.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/BaseExceptions.java
@@ -3,24 +3,32 @@ package org.http4s.blaze.http.parser;
 public class BaseExceptions {
 
     public static abstract class ParserException extends Exception {
+        private static final long serialVersionUID = 8132184654773444925L;
+
         public ParserException(String msg) {
             super(msg);
         }
     }
 
     public static class BadMessage extends ParserException {
+        private static final long serialVersionUID = -6447645402380938086L;
+
         public BadMessage(String msg) {
             super(msg);
         }
     }
 
     public static class BadCharacter extends BadMessage {
+        private static final long serialVersionUID = -6336838845289468590L;
+
         public BadCharacter(String msg) {
             super(msg);
         }
     }
 
     public static class InvalidState extends ParserException {
+        private static final long serialVersionUID = -1803189728615965013L;
+
         public InvalidState(String msg) {
             super(msg);
         }

--- a/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
@@ -6,444 +6,448 @@ import org.http4s.blaze.http.parser.BaseExceptions.BadMessage;
 import org.http4s.blaze.http.parser.BaseExceptions.InvalidState;
 import org.http4s.blaze.util.BufferTools;
 
-/**        This HTTP/1.0 HTTP/1.1 parser is strongly inspired by the awesome Jetty parser
- *         http://www.eclipse.org/jetty/
+/**
+ * This HTTP/1.0 HTTP/1.1 parser is strongly inspired by the awesome Jetty parser
+ * http://www.eclipse.org/jetty/
  */
 public abstract class BodyAndHeaderParser extends ParserBase {
 
-    private static enum HeaderState {
-        START,
-        HEADER_IN_NAME,
-        HEADER_IN_VALUE,
-        END
-    }
+  private static enum HeaderState {
+    START,
+    HEADER_IN_NAME,
+    HEADER_IN_VALUE,
+    END
+  }
 
-    private static enum ChunkState {
-        START,
-        CHUNK_SIZE,
-        CHUNK_PARAMS,
-        CHUNK,
-        CHUNK_LF,
-        CHUNK_TRAILERS,
-        END
-    }
+  private static enum ChunkState {
+    START,
+    CHUNK_SIZE,
+    CHUNK_PARAMS,
+    CHUNK,
+    CHUNK_LF,
+    CHUNK_TRAILERS,
+    END
+  }
 
-    public static enum EndOfContent {
-        UNKNOWN_CONTENT,
-        NO_CONTENT,
-        CONTENT_LENGTH,
-        CHUNKED_CONTENT,
-        EOF_CONTENT,
-        END,
-    }
+  public static enum EndOfContent {
+    UNKNOWN_CONTENT,
+    NO_CONTENT,
+    CONTENT_LENGTH,
+    CHUNKED_CONTENT,
+    EOF_CONTENT,
+    END,
+  }
 
+  private final int headerSizeLimit;
+  private final int maxChunkSize;
 
-    private final int headerSizeLimit;
-    private final int maxChunkSize;
+  private HeaderState _hstate = HeaderState.START;
 
-    private HeaderState _hstate = HeaderState.START;
+  private long _contentLength;
+  private long _contentPosition;
 
-    private long _contentLength;
-    private long _contentPosition;
+  private ChunkState _chunkState;
+  private long _chunkLength;
 
-    private ChunkState _chunkState;
-    private long _chunkLength;
+  private String _headerName;
+  private EndOfContent _endOfContent;
 
-    private String _headerName;
-    private EndOfContent _endOfContent;
+  /* --------------------------------------------------------------------- */
 
-    /* --------------------------------------------------------------------- */
+  protected static final char[] HTTP10Bytes = "HTTP/1.0".toCharArray();
+  protected static final char[] HTTP11Bytes = "HTTP/1.1".toCharArray();
 
-    final protected static char[] HTTP10Bytes  = "HTTP/1.0".toCharArray();
-    final protected static char[] HTTP11Bytes  = "HTTP/1.1".toCharArray();
+  protected static final char[] HTTPS10Bytes = "HTTPS/1.0".toCharArray();
+  protected static final char[] HTTPS11Bytes = "HTTPS/1.1".toCharArray();
 
-    final protected static char[] HTTPS10Bytes = "HTTPS/1.0".toCharArray();
-    final protected static char[] HTTPS11Bytes = "HTTPS/1.1".toCharArray();
+  /* Constructor --------------------------------------------------------- */
 
-    /* Constructor --------------------------------------------------------- */
+  protected BodyAndHeaderParser(
+      int initialBufferSize, int headerSizeLimit, int maxChunkSize, boolean isLenient) {
+    super(initialBufferSize, isLenient);
+    this.headerSizeLimit = headerSizeLimit;
+    this.maxChunkSize = maxChunkSize;
 
-    protected BodyAndHeaderParser(int initialBufferSize, int headerSizeLimit, int maxChunkSize, boolean isLenient) {
-        super(initialBufferSize, isLenient);
-        this.headerSizeLimit = headerSizeLimit;
-        this.maxChunkSize = maxChunkSize;
+    _internalReset();
+  }
 
-        _internalReset();
-    }
+  /**
+   * This is the method called by parser when a HTTP Header name and value is found
+   *
+   * @param name The name of the header
+   * @param value The value of the header
+   * @return True if the parser should return to its caller
+   */
+  protected abstract boolean headerComplete(String name, String value)
+      throws BaseExceptions.BadMessage;
 
-    /**
-     * This is the method called by parser when a HTTP Header name and value is found
-     * @param name The name of the header
-     * @param value The value of the header
-     * @return True if the parser should return to its caller
-     */
-    protected abstract boolean headerComplete(String name, String value) throws BaseExceptions.BadMessage;
+  /** determines if a body must not follow the headers */
+  public abstract boolean mustNotHaveBody();
 
-    /** determines if a body must not follow the headers */
-    public abstract boolean mustNotHaveBody();
+  /* Status methods ---------------------------------------------------- */
 
-    /* Status methods ---------------------------------------------------- */
+  public final boolean headersComplete() {
+    return _hstate == HeaderState.END;
+  }
 
-    public final boolean headersComplete() {
-        return _hstate == HeaderState.END;
-    }
+  /**
+   * Determine if the parser is in a state that is guaranteed to not produce any more body content
+   */
+  public final boolean contentComplete() {
+    return mustNotHaveBody()
+        || _endOfContent == EndOfContent.END
+        || _endOfContent == EndOfContent.NO_CONTENT;
+  }
 
-    /** Determine if the parser is in a state that is guaranteed to not produce any more body content */
-    public final boolean contentComplete() {
-        return mustNotHaveBody() ||
-            _endOfContent == EndOfContent.END ||
-            _endOfContent == EndOfContent.NO_CONTENT;
-    }
+  public final boolean isChunked() {
+    return _endOfContent == EndOfContent.CHUNKED_CONTENT;
+  }
 
-    public final boolean isChunked() {
-        return _endOfContent == EndOfContent.CHUNKED_CONTENT;
-    }
+  public final boolean inChunkedHeaders() {
+    return _chunkState == ChunkState.CHUNK_TRAILERS;
+  }
 
-    public final boolean inChunkedHeaders() {
-        return _chunkState == ChunkState.CHUNK_TRAILERS;
-    }
+  public final boolean definedContentLength() {
+    return _endOfContent == EndOfContent.CONTENT_LENGTH;
+  }
 
-    public final boolean definedContentLength() {
-        return _endOfContent == EndOfContent.CONTENT_LENGTH;
-    }
+  public final EndOfContent getContentType() {
+    return _endOfContent;
+  }
 
-    public final EndOfContent getContentType() {
-        return _endOfContent;
-    }
+  /* ----------------------------------------------------------------- */
 
-    /* ----------------------------------------------------------------- */
+  @Override
+  void reset() {
+    super.reset();
+    _internalReset();
+  }
 
-    @Override
-    void reset() {
-        super.reset();
-        _internalReset();
-    }
+  private void _internalReset() {
+    _hstate = HeaderState.START;
+    _chunkState = ChunkState.START;
 
-    private void _internalReset() {
-        _hstate = HeaderState.START;
-        _chunkState = ChunkState.START;
+    _endOfContent = EndOfContent.UNKNOWN_CONTENT;
 
-        _endOfContent = EndOfContent.UNKNOWN_CONTENT;
+    _contentLength = 0;
+    _contentPosition = 0;
+    _chunkLength = 0;
+  }
 
-        _contentLength = 0;
-        _contentPosition = 0;
-        _chunkLength = 0;
-    }
+  @Override
+  public void shutdownParser() {
+    _hstate = HeaderState.END;
+    _chunkState = ChunkState.END;
+    _endOfContent = EndOfContent.END;
+    super.shutdownParser();
+  }
 
-    @Override
-    public void shutdownParser() {
-        _hstate       = HeaderState.END;
-        _chunkState   = ChunkState.END;
-        _endOfContent = EndOfContent.END;
-        super.shutdownParser();
-    }
+  /**
+   * Parse headers
+   *
+   * @param in input ByteBuffer
+   * @return true if successful, false if more input is needed
+   * @throws BaseExceptions.BadMessage on invalid input
+   * @throws BaseExceptions.InvalidState if called when the parser is not ready to accept headers
+   */
+  @SuppressWarnings("fallthrough")
+  protected final boolean parseHeaders(ByteBuffer in)
+      throws BaseExceptions.BadMessage, BaseExceptions.InvalidState {
 
-    /** Parse headers
-     *
-     * @param in input ByteBuffer
-     * @return true if successful, false if more input is needed
-     * @throws BaseExceptions.BadMessage on invalid input
-     * @throws BaseExceptions.InvalidState if called when the parser is not ready to accept headers
-     */
-    @SuppressWarnings("fallthrough")
-    protected final boolean parseHeaders(ByteBuffer in) throws BaseExceptions.BadMessage, BaseExceptions.InvalidState {
+    headerLoop:
+    while (true) {
+      char ch;
+      switch (_hstate) {
+        case START:
+          _hstate = HeaderState.HEADER_IN_NAME;
+          resetLimit(headerSizeLimit);
 
-        headerLoop: while (true) {
-            char ch;
-            switch (_hstate) {
-                case START:
-                    _hstate = HeaderState.HEADER_IN_NAME;
-                    resetLimit(headerSizeLimit);
+        case HEADER_IN_NAME:
+          for (ch = next(in, false); ch != ':' && ch != HttpTokens.LF; ch = next(in, false)) {
+            if (ch == HttpTokens.EMPTY_BUFF) return false;
+            putChar(ch);
+          }
 
-                case HEADER_IN_NAME:
-                    for(ch = next(in, false); ch != ':' && ch != HttpTokens.LF; ch = next(in, false)) {
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;
-                        putChar(ch);
-                    }
+          // Must be done with headers
+          if (bufferPosition() == 0) {
+            _hstate = HeaderState.END;
 
-                    // Must be done with headers
-                    if (bufferPosition() == 0) {
-                        _hstate = HeaderState.END;
-
-                        // Finished with the whole request
-                        if (_chunkState == ChunkState.CHUNK_TRAILERS) {
-                            shutdownParser();
-                        }
-                        else if ((_endOfContent == EndOfContent.UNKNOWN_CONTENT && mustNotHaveBody())) {
-                            shutdownParser();
-                        }
-
-                        // Done parsing headers
-                        return true;
-                    }
-
-                    if (ch == HttpTokens.LF) {  // Valueless header
-                        String name = getString();
-                        clearBuffer();
-
-                        if (headerComplete(name, "")) {
-                            return true;
-                        }
-
-                        continue headerLoop;    // Still parsing Header name
-                    }
-
-                    _headerName = getString();
-                    clearBuffer();
-                    _hstate = HeaderState.HEADER_IN_VALUE;
-
-                case HEADER_IN_VALUE:
-                    for(ch = next(in, true); ch != HttpTokens.LF; ch = next(in, true)) {
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;
-                        putChar(ch);
-                    }
-
-                    String value;
-                    try { value = getTrimmedString(); }
-                    catch (BaseExceptions.BadMessage e) {
-                        shutdownParser();
-                        throw e;
-                    }
-                    clearBuffer();
-
-                    // If we are not parsing trailer headers, look for some that are of interest to the request
-                    if (_chunkState != ChunkState.CHUNK_TRAILERS) {
-                        if (_headerName.equalsIgnoreCase("Transfer-Encoding")) {
-                            if (value.equalsIgnoreCase("chunked")) {
-                                // chunked always overrides Content-Length
-                                if (_endOfContent != EndOfContent.END) {
-                                    _endOfContent = EndOfContent.CHUNKED_CONTENT;
-                                }
-                            } else if (value.equalsIgnoreCase("identity")) {
-                                // TODO: remove support for identity Transfer-Encoding.
-                                // It  was removed from the specification before it was published 
-                                // (althoug some traces of it remained until errata was released: 
-                                // http://lists.w3.org/Archives/Public/ietf-http-wg-old/2001SepDec/0018.html
-                                // if (_endOfContent == EndOfContent.UNKNOWN_CONTENT) {
-                                //     _endOfContent = EndOfContent.EOF_CONTENT; 
-                                // }
-                            }
-                            else {
-                                shutdownParser();
-                                // TODO: server should return 501 - https://tools.ietf.org/html/rfc7230#page-30
-                                throw new BadMessage("Unknown Transfer-Encoding: " + value);
-                            }
-                        }
-                        else if (_endOfContent != EndOfContent.CHUNKED_CONTENT && _headerName.equalsIgnoreCase("Content-Length")) {
-                            try {
-                                long len = Long.parseLong(value);
-                                if ((_endOfContent == EndOfContent.NO_CONTENT || 
-                                     _endOfContent == EndOfContent.CONTENT_LENGTH) && len != _contentLength) {
-                                    // Multiple different Content-Length headers are an error
-                                    // https://tools.ietf.org/html/rfc7230#page-31
-                                    long oldLen = _contentLength;
-                                    shutdownParser();
-                                    throw new BadMessage("Duplicate Content-Length headers detected: " +
-                                                         oldLen + " and " + len + "\n");
-                                }
-                                else if (len > 0) {
-                                    _contentLength = len;
-                                    _endOfContent = EndOfContent.CONTENT_LENGTH;
-                                }
-                                else if (len == 0) {
-                                    _contentLength = len;
-                                    _endOfContent = EndOfContent.NO_CONTENT;
-                                }
-                                else { // negative content-length
-                                    shutdownParser();
-                                    throw new BadMessage("Cannot have negative Content-Length: '" + len + "'\n");
-                                }
-                            }
-                            catch (NumberFormatException t) {
-                                shutdownParser();
-                                throw new BadMessage("Invalid Content-Length: '" + value + "'\n");
-                            }
-                        }
-                    }
-
-                    // Send off the header and see if we wish to continue
-                    try {
-                        if (headerComplete(_headerName, value)) {
-                            return true;
-                        }
-                    } finally {
-                        _hstate = HeaderState.HEADER_IN_NAME;
-                    }
-
-                    break;
-
-                case END:
-                    shutdownParser();
-                    throw new InvalidState("Header parser reached invalid position.");
-            }   // Switch
-        }   // while loop
-    }
-
-    /** Parses the buffer into body content
-     * @param in ByteBuffer to parse
-     * @return a ByteBuffer with the parsed body content. Buffer in may not be depleted. If more data is
-     *         needed, null is returned. In the case of content complete, an empty ByteBuffer is returned.
-     * @throws BaseExceptions.ParserException
-     */
-    protected final ByteBuffer parseContent(ByteBuffer in) throws BaseExceptions.ParserException {
-        if (contentComplete()) {
-            throw new BaseExceptions.InvalidState("content already complete: " + _endOfContent);
-        } else {
-            switch (_endOfContent) {
-            case UNKNOWN_CONTENT:
-                // This makes sense only for response parsing. Requests must always have
-                // either Content-Length or Transfer-Encoding
-
-                _endOfContent = EndOfContent.EOF_CONTENT;
-                _contentLength = Long.MAX_VALUE;    // Its up to the user to limit a body size
-                return parseContent(in);
-
-            case CONTENT_LENGTH:
-            case EOF_CONTENT:
-                return nonChunkedContent(in);
-
-            case CHUNKED_CONTENT:
-                return chunkedContent(in);
-
-            default:
-                throw new BaseExceptions.InvalidState("not implemented: " + _endOfContent);
+            // Finished with the whole request
+            if (_chunkState == ChunkState.CHUNK_TRAILERS) {
+              shutdownParser();
+            } else if ((_endOfContent == EndOfContent.UNKNOWN_CONTENT && mustNotHaveBody())) {
+              shutdownParser();
             }
-        }
-    }
 
-    private ByteBuffer nonChunkedContent(ByteBuffer in) {
-        final long remaining = _contentLength - _contentPosition;
-        final int buf_size = in.remaining();
+            // Done parsing headers
+            return true;
+          }
 
-        if (buf_size >= remaining) {
-            _contentPosition += remaining;
-            ByteBuffer result = submitPartialBuffer(in, (int)remaining);
+          if (ch == HttpTokens.LF) { // Valueless header
+            String name = getString();
+            clearBuffer();
+
+            if (headerComplete(name, "")) {
+              return true;
+            }
+
+            continue headerLoop; // Still parsing Header name
+          }
+
+          _headerName = getString();
+          clearBuffer();
+          _hstate = HeaderState.HEADER_IN_VALUE;
+
+        case HEADER_IN_VALUE:
+          for (ch = next(in, true); ch != HttpTokens.LF; ch = next(in, true)) {
+            if (ch == HttpTokens.EMPTY_BUFF) return false;
+            putChar(ch);
+          }
+
+          String value;
+          try {
+            value = getTrimmedString();
+          } catch (BaseExceptions.BadMessage e) {
             shutdownParser();
+            throw e;
+          }
+          clearBuffer();
+
+          // If we are not parsing trailer headers, look for some that are of interest to the
+          // request
+          if (_chunkState != ChunkState.CHUNK_TRAILERS) {
+            if (_headerName.equalsIgnoreCase("Transfer-Encoding")) {
+              if (value.equalsIgnoreCase("chunked")) {
+                // chunked always overrides Content-Length
+                if (_endOfContent != EndOfContent.END) {
+                  _endOfContent = EndOfContent.CHUNKED_CONTENT;
+                }
+              } else if (value.equalsIgnoreCase("identity")) {
+                // TODO: remove support for identity Transfer-Encoding.
+                // It  was removed from the specification before it was published
+                // (althoug some traces of it remained until errata was released:
+                // http://lists.w3.org/Archives/Public/ietf-http-wg-old/2001SepDec/0018.html
+                // if (_endOfContent == EndOfContent.UNKNOWN_CONTENT) {
+                //     _endOfContent = EndOfContent.EOF_CONTENT;
+                // }
+              } else {
+                shutdownParser();
+                // TODO: server should return 501 - https://tools.ietf.org/html/rfc7230#page-30
+                throw new BadMessage("Unknown Transfer-Encoding: " + value);
+              }
+            } else if (_endOfContent != EndOfContent.CHUNKED_CONTENT
+                && _headerName.equalsIgnoreCase("Content-Length")) {
+              try {
+                long len = Long.parseLong(value);
+                if ((_endOfContent == EndOfContent.NO_CONTENT
+                        || _endOfContent == EndOfContent.CONTENT_LENGTH)
+                    && len != _contentLength) {
+                  // Multiple different Content-Length headers are an error
+                  // https://tools.ietf.org/html/rfc7230#page-31
+                  long oldLen = _contentLength;
+                  shutdownParser();
+                  throw new BadMessage(
+                      "Duplicate Content-Length headers detected: "
+                          + oldLen
+                          + " and "
+                          + len
+                          + "\n");
+                } else if (len > 0) {
+                  _contentLength = len;
+                  _endOfContent = EndOfContent.CONTENT_LENGTH;
+                } else if (len == 0) {
+                  _contentLength = len;
+                  _endOfContent = EndOfContent.NO_CONTENT;
+                } else { // negative content-length
+                  shutdownParser();
+                  throw new BadMessage("Cannot have negative Content-Length: '" + len + "'\n");
+                }
+              } catch (NumberFormatException t) {
+                shutdownParser();
+                throw new BadMessage("Invalid Content-Length: '" + value + "'\n");
+              }
+            }
+          }
+
+          // Send off the header and see if we wish to continue
+          try {
+            if (headerComplete(_headerName, value)) {
+              return true;
+            }
+          } finally {
+            _hstate = HeaderState.HEADER_IN_NAME;
+          }
+
+          break;
+
+        case END:
+          shutdownParser();
+          throw new InvalidState("Header parser reached invalid position.");
+      } // Switch
+    } // while loop
+  }
+
+  /**
+   * Parses the buffer into body content
+   *
+   * @param in ByteBuffer to parse
+   * @return a ByteBuffer with the parsed body content. Buffer in may not be depleted. If more data
+   *     is needed, null is returned. In the case of content complete, an empty ByteBuffer is
+   *     returned.
+   * @throws BaseExceptions.ParserException
+   */
+  protected final ByteBuffer parseContent(ByteBuffer in) throws BaseExceptions.ParserException {
+    if (contentComplete()) {
+      throw new BaseExceptions.InvalidState("content already complete: " + _endOfContent);
+    } else {
+      switch (_endOfContent) {
+        case UNKNOWN_CONTENT:
+          // This makes sense only for response parsing. Requests must always have
+          // either Content-Length or Transfer-Encoding
+
+          _endOfContent = EndOfContent.EOF_CONTENT;
+          _contentLength = Long.MAX_VALUE; // Its up to the user to limit a body size
+          return parseContent(in);
+
+        case CONTENT_LENGTH:
+        case EOF_CONTENT:
+          return nonChunkedContent(in);
+
+        case CHUNKED_CONTENT:
+          return chunkedContent(in);
+
+        default:
+          throw new BaseExceptions.InvalidState("not implemented: " + _endOfContent);
+      }
+    }
+  }
+
+  private ByteBuffer nonChunkedContent(ByteBuffer in) {
+    final long remaining = _contentLength - _contentPosition;
+    final int buf_size = in.remaining();
+
+    if (buf_size >= remaining) {
+      _contentPosition += remaining;
+      ByteBuffer result = submitPartialBuffer(in, (int) remaining);
+      shutdownParser();
+      return result;
+    } else {
+      if (buf_size > 0) {
+        _contentPosition += buf_size;
+        return submitBuffer(in);
+      } else return null;
+    }
+  }
+
+  @SuppressWarnings("fallthrough")
+  private ByteBuffer chunkedContent(ByteBuffer in)
+      throws BaseExceptions.BadMessage, BaseExceptions.InvalidState {
+    while (true) {
+      char ch;
+      sw:
+      switch (_chunkState) {
+        case START:
+          _chunkState = ChunkState.CHUNK_SIZE;
+          // Don't want the chunk size and extension field to be too long.
+          resetLimit(256);
+
+        case CHUNK_SIZE:
+          assert _contentPosition == 0;
+
+          while (true) {
+
+            ch = next(in, false);
+            if (ch == HttpTokens.EMPTY_BUFF) return null;
+
+            if (HttpTokens.isWhiteSpace(ch) || ch == HttpTokens.SEMI_COLON) {
+              _chunkState = ChunkState.CHUNK_PARAMS;
+              break; // Break out of the while loop, and fall through to params
+            } else if (ch == HttpTokens.LF) {
+              if (_chunkLength == 0) {
+                _hstate = HeaderState.START;
+                _chunkState = ChunkState.CHUNK_TRAILERS;
+              } else _chunkState = ChunkState.CHUNK;
+
+              break sw;
+            } else {
+              _chunkLength = 16 * _chunkLength + HttpTokens.hexCharToInt(ch);
+
+              if (_chunkLength > maxChunkSize) {
+                shutdownParser();
+                throw new BadMessage("Chunk length too large: " + _chunkLength);
+              }
+            }
+          }
+
+        case CHUNK_PARAMS:
+          // Don't store them, for now.
+          for (ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
+            if (ch == HttpTokens.EMPTY_BUFF) return null;
+          }
+
+          // Check to see if this was the last chunk
+          if (_chunkLength == 0) {
+            _hstate = HeaderState.START;
+            _chunkState = ChunkState.CHUNK_TRAILERS;
+          } else _chunkState = ChunkState.CHUNK;
+          break;
+
+        case CHUNK:
+          final long remaining_chunk_size = _chunkLength - _contentPosition;
+          final int buff_size = in.remaining();
+
+          if (remaining_chunk_size <= buff_size) {
+            // End of this chunk
+            ByteBuffer result = submitPartialBuffer(in, (int) remaining_chunk_size);
+            _contentPosition = _chunkLength = 0;
+            _chunkState = ChunkState.CHUNK_LF;
             return result;
-        }
-        else {
-            if (buf_size > 0) {
-                _contentPosition += buf_size;
-                return submitBuffer(in);
-            }
-            else return null;
-        }
+          } else {
+            if (buff_size > 0) {
+              _contentPosition += buff_size;
+              return submitBuffer(in);
+            } else return null;
+          }
+
+        case CHUNK_LF:
+          ch = next(in, false);
+          if (ch == HttpTokens.EMPTY_BUFF) return null;
+
+          if (ch != HttpTokens.LF) {
+            shutdownParser();
+            throw new BadMessage("Bad chunked encoding char: '" + ch + "'");
+          }
+
+          _chunkState = ChunkState.START;
+          break;
+
+        case CHUNK_TRAILERS: // more headers
+          if (parseHeaders(in)) {
+            // headers complete
+            return BufferTools.emptyBuffer();
+          } else {
+            return null;
+          }
+      }
     }
+  }
 
-    @SuppressWarnings("fallthrough")
-    private ByteBuffer chunkedContent(ByteBuffer in) throws BaseExceptions.BadMessage, BaseExceptions.InvalidState {
-        while(true) {
-            char ch;
-            sw: switch (_chunkState) {
-                case START:
-                    _chunkState = ChunkState.CHUNK_SIZE;
-                    // Don't want the chunk size and extension field to be too long.
-                    resetLimit(256);
+  /** Manages the buffer position while submitting the content -------- */
 
-                case CHUNK_SIZE:
-                    assert _contentPosition == 0;
+  // TODO: do we care about these being `read-only`? It does ensure any underlying array is
+  // hidden...
+  private ByteBuffer submitBuffer(ByteBuffer in) {
+    ByteBuffer out = in.asReadOnlyBuffer();
+    in.position(in.limit());
+    return out;
+  }
 
-                    while (true) {
-
-                        ch = next(in, false);
-                        if (ch == HttpTokens.EMPTY_BUFF) return null;
-
-                        if (HttpTokens.isWhiteSpace(ch) || ch == HttpTokens.SEMI_COLON) {
-                            _chunkState = ChunkState.CHUNK_PARAMS;
-                            break;  // Break out of the while loop, and fall through to params
-                        }
-                        else if (ch == HttpTokens.LF) {
-                            if (_chunkLength == 0) {
-                                _hstate = HeaderState.START;
-                                _chunkState = ChunkState.CHUNK_TRAILERS;
-                            }
-                            else _chunkState = ChunkState.CHUNK;
-
-                            break sw;
-                        }
-                        else {
-                            _chunkLength = 16 * _chunkLength + HttpTokens.hexCharToInt(ch);
-
-                            if (_chunkLength > maxChunkSize) {
-                                shutdownParser();
-                                throw new BadMessage("Chunk length too large: " + _chunkLength);
-                            }
-                        }
-                    }
-
-                case CHUNK_PARAMS:
-                    // Don't store them, for now.
-                    for(ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
-                        if (ch == HttpTokens.EMPTY_BUFF) return null;
-                    }
-
-                    // Check to see if this was the last chunk
-                    if (_chunkLength == 0) {
-                        _hstate = HeaderState.START;
-                        _chunkState = ChunkState.CHUNK_TRAILERS;
-                    }
-                    else _chunkState = ChunkState.CHUNK;
-                    break;
-
-                case CHUNK:
-                    final long remaining_chunk_size =  _chunkLength - _contentPosition;
-                    final int buff_size = in.remaining();
-
-                    if (remaining_chunk_size <= buff_size) {
-                        // End of this chunk
-                        ByteBuffer result = submitPartialBuffer(in, (int)remaining_chunk_size);
-                        _contentPosition = _chunkLength = 0;
-                        _chunkState = ChunkState.CHUNK_LF;
-                        return result;
-                    }
-                    else {
-                        if (buff_size > 0) {
-                            _contentPosition += buff_size;
-                            return submitBuffer(in);
-                        }
-                        else return null;
-                    }
-
-                case CHUNK_LF:
-                    ch = next(in, false);
-                    if (ch == HttpTokens.EMPTY_BUFF) return null;
-
-                    if (ch != HttpTokens.LF) {
-                        shutdownParser();
-                        throw new BadMessage("Bad chunked encoding char: '" + ch + "'");
-                    }
-
-                    _chunkState = ChunkState.START;
-                    break;
-
-
-                case CHUNK_TRAILERS:    // more headers
-                    if (parseHeaders(in)) {
-                        // headers complete
-                        return BufferTools.emptyBuffer();
-                    }
-                    else {
-                        return null;
-                    }
-            }
-        }
+  private ByteBuffer submitPartialBuffer(ByteBuffer in, int size) {
+    // Perhaps we are just right? Might be common.
+    if (size == in.remaining()) {
+      return submitBuffer(in);
+    } else {
+      return BufferTools.takeSlice(in, size).asReadOnlyBuffer();
     }
-
-    /** Manages the buffer position while submitting the content -------- */
-
-    // TODO: do we care about these being `read-only`? It does ensure any underlying array is hidden...
-    private ByteBuffer submitBuffer(ByteBuffer in) {
-        ByteBuffer out = in.asReadOnlyBuffer();
-        in.position(in.limit());
-        return out;
-    }
-
-    private ByteBuffer submitPartialBuffer(ByteBuffer in, int size) {
-        // Perhaps we are just right? Might be common.
-        if (size == in.remaining()) {
-            return submitBuffer(in);
-        } else {
-            return BufferTools.takeSlice(in, size).asReadOnlyBuffer();
-        }
-    }
-
+  }
 }

--- a/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/BodyAndHeaderParser.java
@@ -144,6 +144,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
      * @throws BaseExceptions.BadMessage on invalid input
      * @throws BaseExceptions.InvalidState if called when the parser is not ready to accept headers
      */
+    @SuppressWarnings("fallthrough")
     protected final boolean parseHeaders(ByteBuffer in) throws BaseExceptions.BadMessage, BaseExceptions.InvalidState {
 
         headerLoop: while (true) {
@@ -328,6 +329,7 @@ public abstract class BodyAndHeaderParser extends ParserBase {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private ByteBuffer chunkedContent(ByteBuffer in) throws BaseExceptions.BadMessage, BaseExceptions.InvalidState {
         while(true) {
             char ch;

--- a/http/src/main/java/org/http4s/blaze/http/parser/Http1ClientParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/Http1ClientParser.java
@@ -89,6 +89,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
     }
 
     /** parses the request line. Returns true if completed successfully, false if needs input */
+    @SuppressWarnings("fallthrough")
     protected final boolean parseResponseLine(ByteBuffer in) throws BaseExceptions.InvalidState, BaseExceptions.BadMessage {
         try {
             lineLoop: while(true) {
@@ -136,7 +137,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
                         if (!HttpTokens.isDigit(ch)) {
                             shutdownParser();
-                            throw new BadMessage("Received invalid token when needed code: '" + (char)ch + "'");
+                            throw new BadMessage("Received invalid token when needed code: '" + ch + "'");
                         }
                         _statusCode = 10*_statusCode + (ch - HttpTokens.ZERO);
                         _requestLineState = RequestLineState.STATUS_CODE;
@@ -161,7 +162,7 @@ public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
                         if (!HttpTokens.isWhiteSpace(ch)) {
                             shutdownParser();
-                            throw new BadMessage("Invalid request: Expected SPACE but found '" + (char)ch + "'");
+                            throw new BadMessage("Invalid request: Expected SPACE but found '" + ch + "'");
                         }
 
                         _requestLineState = RequestLineState.SPACE2;

--- a/http/src/main/java/org/http4s/blaze/http/parser/Http1ClientParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/Http1ClientParser.java
@@ -5,210 +5,221 @@ import org.http4s.blaze.http.parser.BaseExceptions.*;
 
 public abstract class Http1ClientParser extends BodyAndHeaderParser {
 
-    public Http1ClientParser(int maxResponseLineSize, int maxHeaderLength, int initialBufferSize, int maxChunkSize,
-                             boolean isLenient) {
-        super(initialBufferSize, maxHeaderLength, maxChunkSize, isLenient);
-        this.maxResponseLineSize = maxResponseLineSize;
+  public Http1ClientParser(
+      int maxResponseLineSize,
+      int maxHeaderLength,
+      int initialBufferSize,
+      int maxChunkSize,
+      boolean isLenient) {
+    super(initialBufferSize, maxHeaderLength, maxChunkSize, isLenient);
+    this.maxResponseLineSize = maxResponseLineSize;
 
-        _internalReset();
+    _internalReset();
+  }
+
+  public Http1ClientParser(int initialBufferSize, boolean isLenient) {
+    this(2048, 40 * 1024, initialBufferSize, Integer.MAX_VALUE, isLenient);
+  }
+
+  public Http1ClientParser(boolean isLenient) {
+    this(10 * 1024, isLenient);
+  }
+
+  public Http1ClientParser() {
+    this(false);
+  }
+
+  // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
+  private enum RequestLineState {
+    START,
+    VERSION,
+    SPACE1,
+    STATUS_CODE,
+    SPACE2,
+    REASON,
+    END,
+  }
+
+  private final int maxResponseLineSize;
+
+  private RequestLineState _requestLineState = RequestLineState.START;
+  private String _lineScheme = null;
+  private int _majorVersion = 0;
+  private int _minorVersion = 0;
+  private int _statusCode = 0;
+  private boolean isHeadRequest = false;
+
+  public final boolean isStartState() {
+    return _requestLineState == RequestLineState.START;
+  }
+
+  protected abstract void submitResponseLine(
+      int code, String reason, String scheme, int majorversion, int minorversion);
+
+  public final boolean responseLineComplete() {
+    return _requestLineState == RequestLineState.END;
+  }
+
+  @Override
+  public void shutdownParser() {
+    super
+        .shutdownParser(); // To change body of overridden methods use File | Settings | File
+                           // Templates.
+    _requestLineState = RequestLineState.END;
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    _internalReset();
+  }
+
+  private void _internalReset() {
+    _requestLineState = RequestLineState.START;
+    _lineScheme = null;
+    _majorVersion = 0;
+    _minorVersion = 0;
+    _statusCode = 0;
+    isHeadRequest = false;
+  }
+
+  public final void isHeadRequest(boolean isHeadRequest) {
+    this.isHeadRequest = isHeadRequest;
+  }
+
+  @Override
+  public boolean mustNotHaveBody() {
+    return isHeadRequest || _statusCode < 200 || _statusCode == 204 || _statusCode == 304;
+  }
+
+  /** parses the request line. Returns true if completed successfully, false if needs input */
+  @SuppressWarnings("fallthrough")
+  protected final boolean parseResponseLine(ByteBuffer in)
+      throws BaseExceptions.InvalidState, BaseExceptions.BadMessage {
+    try {
+      lineLoop:
+      while (true) {
+        char ch;
+        switch (_requestLineState) {
+          case START:
+            _requestLineState = RequestLineState.VERSION;
+            resetLimit(maxResponseLineSize);
+
+          case VERSION:
+            for (ch = next(in, false);
+                ch != HttpTokens.SPACE && ch != HttpTokens.TAB;
+                ch = next(in, false)) {
+              if (ch == HttpTokens.EMPTY_BUFF) return false;
+              putChar(ch);
+            }
+
+            _majorVersion = 1;
+            _minorVersion = 1;
+
+            if (arrayMatches(HTTP11Bytes) || arrayMatches(BodyAndHeaderParser.HTTPS11Bytes)) {
+              _majorVersion = 1;
+              _minorVersion = 1;
+            } else if (arrayMatches(HTTP10Bytes) || arrayMatches(HTTPS10Bytes)) {
+              _majorVersion = 1;
+              _minorVersion = 0;
+            } else {
+              String reason = "Bad HTTP version: " + getString();
+              clearBuffer();
+              shutdownParser();
+              throw new BadMessage(reason);
+            }
+
+            _lineScheme = getString(bufferPosition() - 4);
+            clearBuffer();
+
+            // We are through parsing the request line
+            _requestLineState = RequestLineState.SPACE1;
+
+          case SPACE1:
+            // Eat whitespace
+            for (ch = next(in, false);
+                ch == HttpTokens.SPACE || ch == HttpTokens.TAB;
+                ch = next(in, false)) ;
+
+            if (ch == HttpTokens.EMPTY_BUFF) return false;
+
+            if (!HttpTokens.isDigit(ch)) {
+              shutdownParser();
+              throw new BadMessage("Received invalid token when needed code: '" + ch + "'");
+            }
+            _statusCode = 10 * _statusCode + (ch - HttpTokens.ZERO);
+            _requestLineState = RequestLineState.STATUS_CODE;
+
+          case STATUS_CODE:
+            for (ch = next(in, false); HttpTokens.isDigit(ch); ch = next(in, false)) {
+              _statusCode = 10 * _statusCode + (ch - HttpTokens.ZERO);
+            }
+
+            if (ch == HttpTokens.EMPTY_BUFF) return false; // Need more data
+
+            if (_statusCode < 100 || _statusCode >= 600) {
+              shutdownParser();
+              throw new BadMessage(
+                  "Invalid status code '" + _statusCode + "'. Must be between 100 and 599");
+            }
+
+            if (ch == HttpTokens.LF) {
+              endResponseLineParsing("");
+              return true;
+            }
+
+            if (!HttpTokens.isWhiteSpace(ch)) {
+              shutdownParser();
+              throw new BadMessage("Invalid request: Expected SPACE but found '" + ch + "'");
+            }
+
+            _requestLineState = RequestLineState.SPACE2;
+
+          case SPACE2:
+            // Eat whitespace
+            for (ch = next(in, false);
+                ch == HttpTokens.SPACE || ch == HttpTokens.TAB;
+                ch = next(in, false)) ;
+
+            if (ch == HttpTokens.EMPTY_BUFF) return false;
+
+            if (ch == HttpTokens.LF) {
+              endResponseLineParsing("");
+              return true;
+            }
+
+            putChar(ch);
+            _requestLineState = RequestLineState.REASON;
+
+          case REASON:
+            for (ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
+              if (ch == HttpTokens.EMPTY_BUFF) return false;
+              putChar(ch);
+            }
+
+            String reason = getTrimmedString();
+            endResponseLineParsing(reason);
+            return true;
+
+          default:
+            throw new BaseExceptions.InvalidState(
+                "Attempted to parse Response line when already complete."
+                    + "RequestLineState: '"
+                    + _requestLineState
+                    + "'");
+        } // switch
+      } // while loop
+    } catch (BaseExceptions.BadMessage ex) {
+      shutdownParser();
+      throw ex;
     }
+  }
 
-    public Http1ClientParser(int initialBufferSize, boolean isLenient) {
-        this(2048, 40*1024, initialBufferSize, Integer.MAX_VALUE, isLenient);
-    }
+  private void endResponseLineParsing(String reason) {
+    clearBuffer();
 
-    public Http1ClientParser(boolean isLenient) {
-        this(10*1024, isLenient);
-    }
-
-    public Http1ClientParser() {
-        this(false);
-    }
-
-    // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
-    private enum RequestLineState {
-        START,
-        VERSION,
-        SPACE1,
-        STATUS_CODE,
-        SPACE2,
-        REASON,
-        END,
-    }
-
-    private final int maxResponseLineSize;
-
-    private RequestLineState _requestLineState = RequestLineState.START;
-    private String _lineScheme = null;
-    private int _majorVersion = 0;
-    private int _minorVersion = 0;
-    private int _statusCode = 0;
-    private boolean isHeadRequest = false;
-
-    final public boolean isStartState() {
-        return _requestLineState == RequestLineState.START;
-    }
-
-    protected abstract void submitResponseLine(int code, String reason, String scheme, int majorversion, int minorversion);
-
-    public final boolean responseLineComplete() {
-        return _requestLineState == RequestLineState.END;
-    }
-
-    @Override
-    public void shutdownParser() {
-        super.shutdownParser();    //To change body of overridden methods use File | Settings | File Templates.
-        _requestLineState = RequestLineState.END;
-    }
-
-    @Override
-    public void reset() {
-        super.reset();
-        _internalReset();
-    }
-
-    private void _internalReset() {
-        _requestLineState = RequestLineState.START;
-        _lineScheme = null;
-        _majorVersion = 0;
-        _minorVersion = 0;
-        _statusCode = 0;
-        isHeadRequest = false;
-    }
-
-    public final void isHeadRequest(boolean isHeadRequest) {
-        this.isHeadRequest = isHeadRequest;
-    }
-
-    @Override
-    public boolean mustNotHaveBody() {
-        return isHeadRequest ||
-          _statusCode <  200 ||
-          _statusCode == 204 ||
-          _statusCode == 304;
-    }
-
-    /** parses the request line. Returns true if completed successfully, false if needs input */
-    @SuppressWarnings("fallthrough")
-    protected final boolean parseResponseLine(ByteBuffer in) throws BaseExceptions.InvalidState, BaseExceptions.BadMessage {
-        try {
-            lineLoop: while(true) {
-                char ch;
-                switch (_requestLineState) {
-                    case START:
-                        _requestLineState = RequestLineState.VERSION;
-                        resetLimit(maxResponseLineSize);
-
-                    case VERSION:
-                        for(ch = next(in, false); ch != HttpTokens.SPACE && ch != HttpTokens.TAB; ch = next(in, false)) {
-                            if (ch == HttpTokens.EMPTY_BUFF) return false;
-                            putChar(ch);
-                        }
-
-                        _majorVersion = 1;
-                        _minorVersion = 1;
-
-                        if (arrayMatches(HTTP11Bytes) || arrayMatches(BodyAndHeaderParser.HTTPS11Bytes)) {
-                            _majorVersion = 1;
-                            _minorVersion = 1;
-                        }
-                        else if (arrayMatches(HTTP10Bytes) || arrayMatches(HTTPS10Bytes)) {
-                            _majorVersion = 1;
-                            _minorVersion = 0;
-                        }
-                        else {
-                            String reason =  "Bad HTTP version: " + getString();
-                            clearBuffer();
-                            shutdownParser();
-                            throw new BadMessage(reason);
-                        }
-
-                        _lineScheme = getString(bufferPosition() - 4);
-                        clearBuffer();
-
-                        // We are through parsing the request line
-                        _requestLineState = RequestLineState.SPACE1;
-
-                    case SPACE1:
-                        // Eat whitespace
-                        for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
-
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;
-
-                        if (!HttpTokens.isDigit(ch)) {
-                            shutdownParser();
-                            throw new BadMessage("Received invalid token when needed code: '" + ch + "'");
-                        }
-                        _statusCode = 10*_statusCode + (ch - HttpTokens.ZERO);
-                        _requestLineState = RequestLineState.STATUS_CODE;
-
-                    case STATUS_CODE:
-                        for(ch = next(in, false); HttpTokens.isDigit(ch); ch = next(in, false)) {
-                            _statusCode = 10*_statusCode + (ch - HttpTokens.ZERO);
-                        }
-
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;  // Need more data
-
-                        if (_statusCode < 100 || _statusCode >= 600) {
-                            shutdownParser();
-                            throw new BadMessage("Invalid status code '" +
-                                    _statusCode + "'. Must be between 100 and 599");
-                        }
-
-                        if (ch == HttpTokens.LF) {
-                        	endResponseLineParsing("");
-                            return true;
-                        }
-
-                        if (!HttpTokens.isWhiteSpace(ch)) {
-                            shutdownParser();
-                            throw new BadMessage("Invalid request: Expected SPACE but found '" + ch + "'");
-                        }
-
-                        _requestLineState = RequestLineState.SPACE2;
-
-                    case SPACE2:
-                        // Eat whitespace
-                        for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
-
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;
-
-                        if (ch == HttpTokens.LF) {
-                        	endResponseLineParsing("");
-                            return true;
-                        }
-
-                        putChar(ch);
-                        _requestLineState = RequestLineState.REASON;
-
-                    case REASON:
-                        for(ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
-                            if (ch == HttpTokens.EMPTY_BUFF) return false;
-                            putChar(ch);
-                        }
-
-
-
-                        String reason = getTrimmedString();
-                        endResponseLineParsing(reason);
-                        return true;
-
-                    default:
-                        throw new BaseExceptions.InvalidState("Attempted to parse Response line when already complete." +
-                                "RequestLineState: '" + _requestLineState + "'");
-                }    // switch
-            }        // while loop
-        } catch (BaseExceptions.BadMessage ex) {
-            shutdownParser();
-            throw ex;
-        }
-    }
-
-    private void endResponseLineParsing(String reason) {
-    	clearBuffer();
-
-        // We are through parsing the request line
-        _requestLineState = RequestLineState.END;
-        submitResponseLine(_statusCode, reason, _lineScheme, _majorVersion, _minorVersion);
-    }
+    // We are through parsing the request line
+    _requestLineState = RequestLineState.END;
+    submitResponseLine(_statusCode, reason, _lineScheme, _majorVersion, _minorVersion);
+  }
 }

--- a/http/src/main/java/org/http4s/blaze/http/parser/Http1ServerParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/Http1ServerParser.java
@@ -4,214 +4,220 @@ import java.nio.ByteBuffer;
 
 import org.http4s.blaze.http.parser.BaseExceptions.*;
 
-
 public abstract class Http1ServerParser extends BodyAndHeaderParser {
 
-    private enum LineState {
-        START,
-        METHOD,
-        SPACE1,
-        PATH,
-        SPACE2,
-        VERSION,
-        END,
-    }
+  private enum LineState {
+    START,
+    METHOD,
+    SPACE1,
+    PATH,
+    SPACE2,
+    VERSION,
+    END,
+  }
 
-    private final int maxRequestLineSize;
-    private LineState lineState = LineState.START;
-    private String method;
-    private String path;
+  private final int maxRequestLineSize;
+  private LineState lineState = LineState.START;
+  private String method;
+  private String path;
 
-    /**
-     * This is the method called by parser when the HTTP request line is parsed
-     * @param methodString The method as a string
-     * @param path The raw bytes of the PATH.  These are copied into a ByteBuffer that
-     *           will not be changed until this parser is reset and reused.
-     * @param scheme the scheme of the request, either .http' or 'https'. Note that
-     *               this doesn't necessarily correlate with using SSL/TLS.
-     * @param majorVersion major version
-     * @param minorVersion minor version
-     * @return true if handling parsing should return.
-     */
-    public abstract boolean submitRequestLine(
-        String methodString,
-        String path,
-        String scheme,
-        int majorVersion,
-        int minorVersion
-    );
+  /**
+   * This is the method called by parser when the HTTP request line is parsed
+   *
+   * @param methodString The method as a string
+   * @param path The raw bytes of the PATH. These are copied into a ByteBuffer that will not be
+   *     changed until this parser is reset and reused.
+   * @param scheme the scheme of the request, either .http' or 'https'. Note that this doesn't
+   *     necessarily correlate with using SSL/TLS.
+   * @param majorVersion major version
+   * @param minorVersion minor version
+   * @return true if handling parsing should return.
+   */
+  public abstract boolean submitRequestLine(
+      String methodString, String path, String scheme, int majorVersion, int minorVersion);
 
-    /* ------------------------------------------------------------------ */
+  /* ------------------------------------------------------------------ */
 
-    public final boolean requestLineComplete() {
-        return lineState == LineState.END;
-    }
+  public final boolean requestLineComplete() {
+    return lineState == LineState.END;
+  }
 
-    /**
-     * Whether the parser is in the initial state.
-     */
-    public final boolean isStart() {
-        return lineState == LineState.START;
-    }
+  /** Whether the parser is in the initial state. */
+  public final boolean isStart() {
+    return lineState == LineState.START;
+  }
 
-    /* ------------------------------------------------------------------ */
+  /* ------------------------------------------------------------------ */
 
-    @Override
-    public void reset() {
-        super.reset();
-        internalReset();
-    }
+  @Override
+  public void reset() {
+    super.reset();
+    internalReset();
+  }
 
-    private void internalReset() {
-        lineState = LineState.START;
-    }
+  private void internalReset() {
+    lineState = LineState.START;
+  }
 
-    /* ------------------------------------------------------------------ */
+  /* ------------------------------------------------------------------ */
 
-    @Override
-    public void shutdownParser() {
-        super.shutdownParser();
-        lineState = LineState.END;
-    }
+  @Override
+  public void shutdownParser() {
+    super.shutdownParser();
+    lineState = LineState.END;
+  }
 
-    /* ------------------------------------------------------------------ */
-    // the sole Constructor
+  /* ------------------------------------------------------------------ */
+  // the sole Constructor
 
-    public Http1ServerParser(int maxReqLen, int maxHeaderLength, int initialBufferSize, int maxChunkSize) {
-        super(initialBufferSize, maxHeaderLength, maxChunkSize, false);
+  public Http1ServerParser(
+      int maxReqLen, int maxHeaderLength, int initialBufferSize, int maxChunkSize) {
+    super(initialBufferSize, maxHeaderLength, maxChunkSize, false);
 
-        this.maxRequestLineSize = maxReqLen;
-        internalReset();
-    }
+    this.maxRequestLineSize = maxReqLen;
+    internalReset();
+  }
 
-    public Http1ServerParser(int maxReqLen, int maxHeaderLength, int initialBufferSize) {
-        this(maxReqLen, maxHeaderLength, initialBufferSize, Integer.MAX_VALUE);
-    }
+  public Http1ServerParser(int maxReqLen, int maxHeaderLength, int initialBufferSize) {
+    this(maxReqLen, maxHeaderLength, initialBufferSize, Integer.MAX_VALUE);
+  }
 
-    public Http1ServerParser(int initialBufferSize) {
-        this(2048, 40*1024, initialBufferSize);
-    }
+  public Http1ServerParser(int initialBufferSize) {
+    this(2048, 40 * 1024, initialBufferSize);
+  }
 
-    public Http1ServerParser() { this(10*1024); }
+  public Http1ServerParser() {
+    this(10 * 1024);
+  }
 
-    /* ------------------------------------------------------------------ */
+  /* ------------------------------------------------------------------ */
 
-    @Override
-    public boolean mustNotHaveBody() {
-      // A request must always indicate with either content-length or
-      // transfer-encoding if it is going to have a body.
-      return !(definedContentLength() || isChunked());
-    }
+  @Override
+  public boolean mustNotHaveBody() {
+    // A request must always indicate with either content-length or
+    // transfer-encoding if it is going to have a body.
+    return !(definedContentLength() || isChunked());
+  }
 
-    /* ------------------------------------------------------------------ */
+  /* ------------------------------------------------------------------ */
 
-    /** parses the request line. Returns true if completed successfully, false if needs input */
-    @SuppressWarnings("fallthrough")
-    protected final boolean parseRequestLine(ByteBuffer in) throws InvalidState, BadMessage {
-        lineLoop: while(true) {
-            char ch;
-            switch (lineState) {
-                case START:
-                    lineState = LineState.METHOD;
-                    resetLimit(maxRequestLineSize);
+  /** parses the request line. Returns true if completed successfully, false if needs input */
+  @SuppressWarnings("fallthrough")
+  protected final boolean parseRequestLine(ByteBuffer in) throws InvalidState, BadMessage {
+    lineLoop:
+    while (true) {
+      char ch;
+      switch (lineState) {
+        case START:
+          lineState = LineState.METHOD;
+          resetLimit(maxRequestLineSize);
 
-                case METHOD:
-                    for(ch = next(in, false); HttpTokens.A <= ch && ch <= HttpTokens.Z; ch = next(in, false)) {
-                        putChar(ch);
-                    }
+        case METHOD:
+          for (ch = next(in, false);
+              HttpTokens.A <= ch && ch <= HttpTokens.Z;
+              ch = next(in, false)) {
+            putChar(ch);
+          }
 
-                    if (ch == HttpTokens.EMPTY_BUFF) return false;
+          if (ch == HttpTokens.EMPTY_BUFF) return false;
 
-                    method = getString();
-                    clearBuffer();
+          method = getString();
+          clearBuffer();
 
+          if (!HttpTokens.isWhiteSpace(ch)) {
+            String badmethod = method + ch;
+            shutdownParser();
+            throw new BadMessage("Invalid request method: '" + badmethod + "'");
+          }
 
-                    if (!HttpTokens.isWhiteSpace(ch)) {
-                        String badmethod = method + ch;
-                        shutdownParser();
-                        throw new BadMessage("Invalid request method: '" + badmethod + "'");
-                    }
+          lineState = LineState.SPACE1;
 
-                   lineState = LineState.SPACE1;
+        case SPACE1:
+          // Eat whitespace
+          for (ch = next(in, false);
+              ch == HttpTokens.SPACE || ch == HttpTokens.TAB;
+              ch = next(in, false)) ;
 
-                case SPACE1:
-                    // Eat whitespace
-                    for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
+          if (ch == HttpTokens.EMPTY_BUFF) return false;
 
-                    if (ch == HttpTokens.EMPTY_BUFF) return false;
+          putChar(ch);
+          lineState = LineState.PATH;
 
-                    putChar(ch);
-                    lineState = LineState.PATH;
+        case PATH:
+          for (ch = next(in, false);
+              ch != HttpTokens.SPACE && ch != HttpTokens.TAB;
+              ch = next(in, false)) {
+            if (ch == HttpTokens.EMPTY_BUFF) return false;
+            putChar(ch);
+          }
 
-                case PATH:
-                    for(ch = next(in, false); ch != HttpTokens.SPACE && ch != HttpTokens.TAB; ch = next(in, false)) {
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;
-                        putChar(ch);
-                    }
+          path = getString();
+          clearBuffer();
 
-                    path = getString();
-                    clearBuffer();
+          lineState = LineState.SPACE2;
 
-                    lineState = LineState.SPACE2;
+        case SPACE2:
+          // Eat whitespace
+          for (ch = next(in, false);
+              ch == HttpTokens.SPACE || ch == HttpTokens.TAB;
+              ch = next(in, false)) ;
 
-                case SPACE2:
-                    // Eat whitespace
-                    for(ch = next(in, false); ch == HttpTokens.SPACE || ch == HttpTokens.TAB; ch = next(in, false));
+          if (ch == HttpTokens.EMPTY_BUFF) return false;
 
-                    if (ch == HttpTokens.EMPTY_BUFF) return false;
+          if (ch != 'H') {
+            shutdownParser();
+            throw new BadMessage("Http version started with illegal character: " + ch);
+          }
 
-                    if (ch != 'H') {
-                        shutdownParser();
-                        throw new BadMessage("Http version started with illegal character: " + ch);
-                    }
+          putChar(ch);
+          lineState = LineState.VERSION;
 
-                    putChar(ch);
-                    lineState = LineState.VERSION;
+        case VERSION:
+          for (ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
+            if (ch == HttpTokens.EMPTY_BUFF) return false;
+            putChar(ch);
+          }
 
-                case VERSION:
-                    for(ch = next(in, false); ch != HttpTokens.LF; ch = next(in, false)) {
-                        if (ch == HttpTokens.EMPTY_BUFF) return false;
-                        putChar(ch);
-                    }
+          int majorVersion;
+          int minorVersion;
+          String scheme;
 
-                    int majorVersion;
-                    int minorVersion;
-                    String scheme;
+          if (arrayMatches(HTTP11Bytes)) {
+            majorVersion = 1;
+            minorVersion = 1;
+            scheme = "http";
+          } else if (arrayMatches(HTTPS11Bytes)) {
+            majorVersion = 1;
+            minorVersion = 1;
+            scheme = "https";
+          } else if (arrayMatches(HTTP10Bytes)) {
+            majorVersion = 1;
+            minorVersion = 0;
+            scheme = "http";
+          } else if (arrayMatches(HTTPS10Bytes)) {
+            majorVersion = 1;
+            minorVersion = 0;
+            scheme = "https";
+          } else {
+            String reason = "Bad HTTP version: " + getString();
+            clearBuffer();
+            shutdownParser();
+            throw new BadMessage(reason);
+          }
 
-                    if (arrayMatches(HTTP11Bytes)) {
-                        majorVersion = 1;
-                        minorVersion = 1;
-                        scheme = "http";
-                    } else if (arrayMatches(HTTPS11Bytes)) {
-                        majorVersion = 1;
-                        minorVersion = 1;
-                        scheme = "https";
-                    } else if (arrayMatches(HTTP10Bytes)) {
-                        majorVersion = 1;
-                        minorVersion = 0;
-                        scheme = "http";
-                    } else if (arrayMatches(HTTPS10Bytes)) {
-                        majorVersion = 1;
-                        minorVersion = 0;
-                        scheme = "https";
-                    } else {
-                        String reason =  "Bad HTTP version: " + getString();
-                        clearBuffer();
-                        shutdownParser();
-                        throw new BadMessage(reason);
-                    }
+          clearBuffer();
 
-                    clearBuffer();
+          // We are through parsing the request line
+          lineState = LineState.END;
+          return !submitRequestLine(method, path, scheme, majorVersion, minorVersion);
 
-                    // We are through parsing the request line
-                    lineState = LineState.END;
-                    return !submitRequestLine(method, path, scheme, majorVersion, minorVersion);
-
-                default:
-                    throw new InvalidState(
-                            "Attempted to parse Request line when already " +
-                                    "complete. LineState: '" + lineState + "'");
-            }    // switch
-        }        // while loop
-    }
+        default:
+          throw new InvalidState(
+              "Attempted to parse Request line when already "
+                  + "complete. LineState: '"
+                  + lineState
+                  + "'");
+      } // switch
+    } // while loop
+  }
 }

--- a/http/src/main/java/org/http4s/blaze/http/parser/Http1ServerParser.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/Http1ServerParser.java
@@ -106,6 +106,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
     /* ------------------------------------------------------------------ */
 
     /** parses the request line. Returns true if completed successfully, false if needs input */
+    @SuppressWarnings("fallthrough")
     protected final boolean parseRequestLine(ByteBuffer in) throws InvalidState, BadMessage {
         lineLoop: while(true) {
             char ch;
@@ -126,7 +127,7 @@ public abstract class Http1ServerParser extends BodyAndHeaderParser {
 
 
                     if (!HttpTokens.isWhiteSpace(ch)) {
-                        String badmethod = method + (char)ch;
+                        String badmethod = method + ch;
                         shutdownParser();
                         throw new BadMessage("Invalid request method: '" + badmethod + "'");
                     }

--- a/http/src/main/java/org/http4s/blaze/http/parser/HttpTokens.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/HttpTokens.java
@@ -40,7 +40,7 @@ public final class HttpTokens
             return ch - A + 10;
         }
         else {
-            throw new BadCharacter("Bad hex char: " + (char)ch);
+            throw new BadCharacter("Bad hex char: " + ch);
         }
     }
 

--- a/http/src/main/java/org/http4s/blaze/http/parser/HttpTokens.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/HttpTokens.java
@@ -2,60 +2,52 @@ package org.http4s.blaze.http.parser;
 
 import org.http4s.blaze.http.parser.BaseExceptions.BadCharacter;
 
+public final class HttpTokens {
+  // Needs more input
+  static final char EMPTY_BUFF = 0xFFFF;
 
-public final class HttpTokens
-{
-    // Needs more input
-    static final char EMPTY_BUFF = 0xFFFF;
+  // replacement for invalid octets
+  static final char REPLACEMENT = 0xFFFD;
 
-    // replacement for invalid octets
-    static final char REPLACEMENT= 0xFFFD;
+  // Terminal symbols.
+  static final char COLON = ':';
+  static final char TAB = '\t';
+  static final char LF = '\n';
+  static final char CR = '\r';
+  static final char SPACE = ' ';
+  static final char[] CRLF = {CR, LF};
+  static final char SEMI_COLON = ';';
 
-    // Terminal symbols.
-    static final char COLON      = ':';
-    static final char TAB        = '\t';
-    static final char LF         = '\n';
-    static final char CR         = '\r';
-    static final char SPACE      = ' ';
-    static final char[] CRLF     = {CR, LF};
-    static final char SEMI_COLON = ';';
+  static final byte ZERO = '0';
+  static final byte NINE = '9';
+  static final byte A = 'A';
+  static final byte F = 'F';
+  static final byte Z = 'Z';
+  static final byte a = 'a';
+  static final byte f = 'f';
+  static final byte z = 'z';
 
-    final static byte ZERO = '0';
-    final static byte NINE = '9';
-    final static byte A    = 'A';
-    final static byte F    = 'F';
-    final static byte Z    = 'Z';
-    final static byte a    = 'a';
-    final static byte f    = 'f';
-    final static byte z    = 'z';
-
-    public static int hexCharToInt(final char ch) throws BadCharacter {
-        if (ZERO <= ch && ch <= NINE) {
-            return ch - ZERO;
-        }
-        else if (a <= ch && ch <= f) {
-            return ch - a + 10;
-        }
-        else if (A <= ch && ch <= F) {
-            return ch - A + 10;
-        }
-        else {
-            throw new BadCharacter("Bad hex char: " + ch);
-        }
+  public static int hexCharToInt(final char ch) throws BadCharacter {
+    if (ZERO <= ch && ch <= NINE) {
+      return ch - ZERO;
+    } else if (a <= ch && ch <= f) {
+      return ch - a + 10;
+    } else if (A <= ch && ch <= F) {
+      return ch - A + 10;
+    } else {
+      throw new BadCharacter("Bad hex char: " + ch);
     }
+  }
 
-    public static boolean isDigit(final char ch) {
-        return HttpTokens.NINE >= ch && ch >= HttpTokens.ZERO;
-    }
+  public static boolean isDigit(final char ch) {
+    return HttpTokens.NINE >= ch && ch >= HttpTokens.ZERO;
+  }
 
-    public static boolean isHexChar(byte ch) {
-        return ZERO <= ch && ch <= NINE ||
-                  a <= ch && ch <= f    ||
-                  A <= ch && ch <= F;
-    }
+  public static boolean isHexChar(byte ch) {
+    return ZERO <= ch && ch <= NINE || a <= ch && ch <= f || A <= ch && ch <= F;
+  }
 
-    public static boolean isWhiteSpace(char ch) {
-        return ch == HttpTokens.SPACE || ch == HttpTokens.TAB;
-    }
-
+  public static boolean isWhiteSpace(char ch) {
+    return ch == HttpTokens.SPACE || ch == HttpTokens.TAB;
+  }
 }

--- a/http/src/main/java/org/http4s/blaze/http/parser/ParserBase.java
+++ b/http/src/main/java/org/http4s/blaze/http/parser/ParserBase.java
@@ -1,185 +1,179 @@
 package org.http4s.blaze.http.parser;
 
-
 import java.nio.ByteBuffer;
 import org.http4s.blaze.http.parser.BaseExceptions.BadMessage;
 import org.http4s.blaze.http.parser.BaseExceptions.BadCharacter;
 
-
 public abstract class ParserBase {
 
-    ParserBase(int initialBufferSize, boolean isLenient) {
-        _internalBuffer = new char[initialBufferSize];
-        _isLenient = isLenient;
-        clearBuffer();
+  ParserBase(int initialBufferSize, boolean isLenient) {
+    _internalBuffer = new char[initialBufferSize];
+    _isLenient = isLenient;
+    clearBuffer();
+  }
+
+  private final boolean _isLenient;
+
+  private int _bufferPosition = 0;
+  private char[] _internalBuffer;
+
+  // Signals if the last char was a '\r' and if the next one needs to be a '\n'
+  private boolean _cr;
+
+  // For signalling overflow of the String buffer
+  private int _segmentByteLimit;
+  private int _segmentBytePosition;
+
+  /** for shutting down the parser and its state */
+  public void shutdownParser() {
+    clearBuffer();
+  }
+
+  void reset() {
+    clearBuffer();
+  }
+
+  /** Store the char in the internal buffer */
+  protected final void putChar(char c) {
+    final int clen = _internalBuffer.length;
+    if (clen == _bufferPosition) {
+      final char[] next = new char[2 * clen + 1];
+
+      System.arraycopy(_internalBuffer, 0, next, 0, _bufferPosition);
+      _internalBuffer = next;
     }
 
-    private final boolean _isLenient;
+    _internalBuffer[_bufferPosition++] = c;
+  }
 
-    private int _bufferPosition = 0;
-    private char[] _internalBuffer;
+  protected final int bufferPosition() {
+    return _bufferPosition;
+  }
 
+  protected final boolean isLenient() {
+    return _isLenient;
+  }
 
-    // Signals if the last char was a '\r' and if the next one needs to be a '\n'
-    private boolean _cr;
+  protected final void clearBuffer() {
+    _bufferPosition = 0;
+  }
 
-    // For signalling overflow of the String buffer
-    private int _segmentByteLimit;
-    private int _segmentBytePosition;
+  protected final String getString() {
+    return getString(0, _bufferPosition);
+  }
 
-    /** for shutting down the parser and its state */
-    public void shutdownParser() {
-        clearBuffer();
+  protected final String getString(int end) {
+    return getString(0, end);
+  }
+
+  protected final String getString(int start, int end) {
+    if (end > _bufferPosition) {
+      throw new IndexOutOfBoundsException("Requested: " + end + ", max: " + _bufferPosition);
     }
 
-    void reset() {
-       clearBuffer();
+    String str = new String(_internalBuffer, start, end);
+    return str;
+  }
+
+  /** Returns the string in the buffer minus an leading or trailing whitespace or quotes */
+  protected final String getTrimmedString() throws BadMessage {
+    if (_bufferPosition == 0) return "";
+
+    int start = 0;
+    boolean quoted = false;
+    // Look for start
+    while (start < _bufferPosition) {
+      final char ch = _internalBuffer[start];
+      if (ch == '"') {
+        quoted = true;
+        break;
+      } else if (ch != HttpTokens.SPACE && ch != HttpTokens.TAB) {
+        break;
+      }
+      start++;
     }
 
-    /** Store the char in the internal buffer */
-    final protected void putChar(char c) {
-        final int clen = _internalBuffer.length;
-        if (clen == _bufferPosition) {
-            final char[] next = new char[2 * clen + 1];
+    int end = _bufferPosition; // Position is of next write
 
-            System.arraycopy(_internalBuffer, 0, next, 0, _bufferPosition);
-            _internalBuffer = next;
+    // Look for end
+    while (end > start) {
+      final char ch = _internalBuffer[end - 1];
+
+      if (quoted) {
+        if (ch == '"') break;
+        else if (ch != HttpTokens.SPACE && ch != HttpTokens.TAB) {
+          throw new BadMessage("String might not quoted correctly: '" + getString() + "'");
         }
-
-        _internalBuffer[_bufferPosition++] = c;
+      } else if (ch != HttpTokens.SPACE && ch != HttpTokens.TAB) break;
+      end--;
     }
 
-    final protected int bufferPosition() {
-        return _bufferPosition;
+    String str = new String(_internalBuffer, start, end - start);
+
+    return str;
+  }
+
+  protected final boolean arrayMatches(final char[] chars) {
+    if (chars.length != _bufferPosition) return false;
+
+    for (int i = 0; i < _bufferPosition; i++) {
+      if (chars[i] != _internalBuffer[i]) return false;
     }
 
-    final protected boolean isLenient() {
-        return _isLenient;
+    return true;
+  }
+
+  /* ------------------------------------------------------------------- */
+
+  protected final void resetLimit(int limit) {
+    _segmentByteLimit = limit;
+    _segmentBytePosition = 0;
+  }
+
+  // Removes CRs but returns LFs
+  protected final char next(final ByteBuffer buffer, boolean allow8859)
+      throws BaseExceptions.BadMessage {
+
+    if (!buffer.hasRemaining()) return HttpTokens.EMPTY_BUFF;
+
+    if (_segmentByteLimit <= _segmentBytePosition) {
+      shutdownParser();
+      throw new BaseExceptions.BadMessage("Request length limit exceeded: " + _segmentByteLimit);
     }
 
-    final protected void clearBuffer() {
-        _bufferPosition = 0;
+    final byte b = buffer.get();
+    _segmentBytePosition++;
+
+    // If we ended on a CR, make sure we are
+    if (_cr) {
+      if (b != HttpTokens.LF) {
+        throw new BadCharacter("Invalid sequence: LF didn't follow CR: " + b);
+      }
+      _cr = false;
+      return (char) b; // must be LF
     }
 
-    final protected String getString() {
-        return getString(0, _bufferPosition);
+    // Make sure its a valid character
+    if (b < HttpTokens.SPACE) {
+      if (b == HttpTokens.CR) { // Set the flag to check for _cr and just run again
+        _cr = true;
+        return next(buffer, allow8859);
+      } else if (b == HttpTokens.TAB || allow8859 && b < 0) {
+        return (char) (b & 0xff);
+      } else if (b == HttpTokens.LF) {
+        return (char)
+            b; // A backend should accept a bare linefeed.
+               // http://tools.ietf.org/html/rfc2616#section-19.3
+      } else if (isLenient()) {
+        return HttpTokens.REPLACEMENT;
+      } else {
+        shutdownParser();
+        throw new BadCharacter(
+            "Invalid char: '" + (char) (b & 0xff) + "', 0x" + Integer.toHexString(b));
+      }
     }
 
-    final protected String getString(int end) {
-        return getString(0, end);
-    }
-
-    final protected String getString(int start, int end) {
-        if (end > _bufferPosition) {
-            throw new IndexOutOfBoundsException("Requested: " + end + ", max: " + _bufferPosition);
-        }
-
-        String str = new String(_internalBuffer, start, end);
-        return str;
-    }
-
-    /** Returns the string in the buffer minus an leading or trailing whitespace or quotes */
-    final protected String getTrimmedString() throws BadMessage {
-        if (_bufferPosition == 0) return "";
-
-        int start = 0;
-        boolean quoted = false;
-        // Look for start
-        while (start < _bufferPosition) {
-            final char ch = _internalBuffer[start];
-            if (ch == '"') {
-                quoted = true;
-                break;
-            }
-            else if (ch != HttpTokens.SPACE && ch != HttpTokens.TAB) {
-                break;
-            }
-            start++;
-        }
-
-        int end = _bufferPosition;  // Position is of next write
-
-        // Look for end
-        while(end > start) {
-            final char ch = _internalBuffer[end - 1];
-
-            if (quoted) {
-                if (ch == '"') break;
-                else if (ch != HttpTokens.SPACE && ch != HttpTokens.TAB) {
-                    throw new BadMessage("String might not quoted correctly: '" + getString() + "'");
-                }
-            }
-            else if (ch != HttpTokens.SPACE && ch != HttpTokens.TAB) break;
-            end--;
-        }
-
-        String str = new String(_internalBuffer, start, end - start);
-
-        return str;
-    }
-
-    final protected boolean arrayMatches(final char[] chars) {
-        if (chars.length != _bufferPosition) return false;
-
-        for (int i = 0; i < _bufferPosition; i++) {
-            if (chars[i] != _internalBuffer[i])
-                return false;
-        }
-
-        return true;
-    }
-
-    /* ------------------------------------------------------------------- */
-
-    final protected void resetLimit(int limit) {
-        _segmentByteLimit = limit;
-        _segmentBytePosition = 0;
-    }
-
-    // Removes CRs but returns LFs
-    final protected char next(final ByteBuffer buffer, boolean allow8859) throws BaseExceptions.BadMessage {
-
-        if (!buffer.hasRemaining()) return HttpTokens.EMPTY_BUFF;
-
-        if (_segmentByteLimit <= _segmentBytePosition) {
-            shutdownParser();
-            throw new BaseExceptions.BadMessage("Request length limit exceeded: " + _segmentByteLimit);
-        }
-
-        final byte b = buffer.get();
-        _segmentBytePosition++;
-
-        // If we ended on a CR, make sure we are
-        if (_cr) {
-            if (b != HttpTokens.LF) {
-                throw new BadCharacter("Invalid sequence: LF didn't follow CR: " + b);
-            }
-            _cr = false;
-            return (char)b;  // must be LF
-        }
-
-        // Make sure its a valid character
-        if (b < HttpTokens.SPACE) {
-            if (b == HttpTokens.CR) {   // Set the flag to check for _cr and just run again
-                _cr = true;
-                return next(buffer, allow8859);
-            }
-            else if (b == HttpTokens.TAB || allow8859 && b < 0) {
-                return (char)(b & 0xff);
-            }
-            else if (b == HttpTokens.LF) {
-                return (char)b; // A backend should accept a bare linefeed. http://tools.ietf.org/html/rfc2616#section-19.3
-            }
-            else if (isLenient()) {
-                return HttpTokens.REPLACEMENT;
-            }
-            else {
-                shutdownParser();
-                throw new BadCharacter("Invalid char: '" + (char)(b & 0xff) + "', 0x" + Integer.toHexString(b));
-            }
-        }
-
-        // valid ascii char
-        return (char)b;
-    }
+    // valid ascii char
+    return (char) b;
+  }
 }


### PR DESCRIPTION
Extends #409 by formatting the result.

As an old Java developer, I'm not thrilled about the two-space indent, but it's closer to Scala and there was a convenient tool on hand.