### PR TITLE
Don't assume checkError is called on NonFatal

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -11,7 +11,6 @@ import org.http4s.blaze.pipeline.Command._
 import org.http4s.blaze.util.{BufferTools, FutureUnit}
 
 import scala.concurrent.{Future, Promise}
-import scala.util.control.NonFatal
 
 import java.nio.channels._
 import java.nio.ByteBuffer
@@ -109,7 +108,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
         logger.debug(e)("Channel Group was shutdown")
         EOF
 
-      case NonFatal(t) => super.checkError(t)
+      case t => super.checkError(t)
     }
 
   override protected def doClosePipeline(cause: Option[Throwable]): Unit = {


### PR DESCRIPTION
Addresses [graceless handling of OOME](https://gitter.im/http4s/http4s?at=5f980c77bbffc02b58421870).

```
Exception in thread "Thread-42" scala.MatchError: java.lang.OutOfMemoryError: Direct buffer memory (of class java.lang.OutOfMemoryError)
    at org.http4s.blaze.channel.nio2.ByteBufferHead.checkError(ByteBufferHead.scala:107)
    at org.http4s.blaze.channel.nio2.ByteBufferHead$$anon$1.failed(ByteBufferHead.scala:51)
    at org.http4s.blaze.channel.nio2.ByteBufferHead$$anon$1.failed(ByteBufferHead.scala:49)
    at sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:129)
    at sun.nio.ch.Invoker$2.run(Invoker.java:219)
    at sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.lang.Thread.run(Thread.java:834)
```