### PR TITLE
Add inferred parens to nullary calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ dist: xenial
 matrix:
   include:
   - jdk: openjdk8
-    scala: 2.12.11
+    scala: 2.12.12
   - jdk: openjdk8
     scala: 2.11.12
   - jdk: openjdk8
-    scala: 2.13.2
+    scala: 2.13.3
   - jdk: openjdk11
-    scala: 2.12.11
+    scala: 2.12.12
 env:
   global:
     secure: GFb3iprmlEb7iy5kA2vCdEMgxMOrWrSPnzLMoU9bCase/5UvNXp0quHzwDlLO9oqj2x+VRBRgJNngYyGB5HU0sRjlvgd2FXAwb5xn3LvGHHJB+j0oVxaYO2DuMeRG9MWuds+IN9EPbmbv36lFHc5NzZZG2ZI9v5+wAJjnCy8QOQ=

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import BlazePlugin._
 
 lazy val commonSettings = Seq(
   description := "NIO Framework for Scala",
-  scalaVersion := "2.12.11",
-  crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.2"),
+  crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3"),
+  scalaVersion := crossScalaVersions.value.filter(_.startsWith("2.")).last,
   scalacOptions := scalacOptionsFor(scalaVersion.value),
   scalacOptions in Test ~= (_.filterNot(Set("-Ywarn-dead-code", "-Wdead-code"))), // because mockito
   scalacOptions in (Compile, doc) += "-no-link-warnings",

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1HeadStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/NIO1HeadStage.scala
@@ -187,7 +187,7 @@ private[nio1] final class NIO1HeadStage(
 
   final override def readRequest(size: Int): Future[ByteBuffer] = {
     logger.trace(s"NIOHeadStage received a read request of size $size")
-    val p = Promise[ByteBuffer]
+    val p = Promise[ByteBuffer]()
 
     selectorLoop.executeTask(new selectorLoop.LoopRunnable {
       override def run(scratchBuffer: ByteBuffer): Unit =
@@ -230,7 +230,7 @@ private[nio1] final class NIO1HeadStage(
 
   final override def writeRequest(data: collection.Seq[ByteBuffer]): Future[Unit] = {
     logger.trace(s"NIO1HeadStage Write Request: $data")
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     selectorLoop.executeTask(new selectorLoop.LoopRunnable {
       override def run(scratch: ByteBuffer): Unit =
         if (closedReason != null) {

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -34,7 +34,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
       case Some(cause) => Future.failed(cause)
       case None if data.isEmpty => FutureUnit
       case None =>
-        val p = Promise[Unit]
+        val p = Promise[Unit]()
         val srcs = data.toArray
 
         def go(index: Int): Unit =
@@ -66,7 +66,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
     }
 
   def readRequest(size: Int): Future[ByteBuffer] = {
-    val p = Promise[ByteBuffer]
+    val p = Promise[ByteBuffer]()
     scratchBuffer.clear()
 
     if (size >= 0 && size < bufferSize)

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ClientChannelFactory.scala
@@ -45,7 +45,7 @@ final class ClientChannelFactory(
   def connect(
       remoteAddress: SocketAddress,
       bufferSize: Int = bufferSize): Future[HeadStage[ByteBuffer]] = {
-    val p = Promise[HeadStage[ByteBuffer]]
+    val p = Promise[HeadStage[ByteBuffer]]()
 
     try {
       val ch = AsynchronousSocketChannel.open(group.orNull)

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -188,7 +188,7 @@ sealed trait Tail[I] extends Stage {
   /** Arranges a timeout for a write request */
   private def checkTimeout[T](timeout: Duration, f: Future[T]): Future[T] =
     if (timeout.isFinite) {
-      val p = Promise[T]
+      val p = Promise[T]()
       scheduleTimeout(p, f, timeout)
       p.future
     } else f

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/ByteToObjectStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/ByteToObjectStage.scala
@@ -74,7 +74,7 @@ trait ByteToObjectStage[O] extends MidStage[ByteBuffer, O] {
     else startReadDecode()
 
   private def startReadDecode(): Future[O] = {
-    val p = Promise[O]
+    val p = Promise[O]()
     readAndDecodeLoop(p)
     p.future
   }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -89,7 +89,7 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
     writeArray(Array(data))
 
   override def readRequest(size: Int): Future[ByteBuffer] = {
-    val p = Promise[ByteBuffer]
+    val p = Promise[ByteBuffer]()
     serialExec.execute(new Runnable { def run() = doRead(size, p) })
     p.future
   }
@@ -97,7 +97,7 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
   /////////////////////////////////////////////////////////////////////
 
   private[this] def writeArray(data: Array[ByteBuffer]): Future[Unit] = {
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     serialExec.execute(new Runnable { def run(): Unit = doWrite(data, p) })
     p.future
   }

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/monitors/IntervalConnectionMonitor.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/monitors/IntervalConnectionMonitor.scala
@@ -101,7 +101,7 @@ class IntervalConnectionMonitor(val interval: Duration) extends ConnectionMonito
         outbound.getMean(),
         outbound.getTotal(),
         conns.getMean(),
-        conns.getTotal,
+        conns.getTotal(),
         conns.getLive())
     }))
 

--- a/core/src/main/scala/org/http4s/blaze/util/Execution.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/Execution.scala
@@ -26,7 +26,7 @@ object Execution {
     if (!d.isFinite) f
     else if (f.isCompleted) f
     else {
-      val p = Promise[T]
+      val p = Promise[T]()
       val r = new Runnable {
         def run(): Unit =
           if (p.tryComplete(fallback))

--- a/core/src/main/scala/org/http4s/blaze/util/ReadPool.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/ReadPool.scala
@@ -49,7 +49,7 @@ private[blaze] class ReadPool[T] {
       messageConsumed(m)
       Future.successful(m)
     } else {
-      val p = Promise[T]
+      val p = Promise[T]()
       readInto(p)
       p.future
     }

--- a/core/src/main/scala/org/http4s/blaze/util/StageTools.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/StageTools.scala
@@ -49,7 +49,7 @@ private[http4s] object StageTools {
             case f @ Failure(_) => p.tryComplete(f)
           }(Execution.trampoline)
 
-      val p = Promise[ByteBuffer]
+      val p = Promise[ByteBuffer]()
       accLoop(bytes, new ArrayBuffer[ByteBuffer](8), p)
       p.future
     }

--- a/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/channel/ChannelSpec.scala
@@ -101,7 +101,7 @@ abstract class BaseChannelSpec extends Specification {
   }
 
   class ZeroWritingStage(batch: Boolean) extends TailStage[ByteBuffer] {
-    private[this] val writeResult = Promise[Unit]
+    private[this] val writeResult = Promise[Unit]()
 
     def name = this.getClass.getSimpleName
 

--- a/core/src/test/scala/org/http4s/blaze/pipeline/PipelineSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/PipelineSpec.scala
@@ -68,7 +68,7 @@ class PipelineSpec extends Specification {
 
       p.findInboundStage(classOf[Noop[Int]]).get should_== noop
       p.findInboundStage(noop.name).get should_== noop
-      noop.removeStage
+      noop.removeStage()
       p.findInboundStage(classOf[Noop[Int]]) must_== None
     }
 
@@ -79,7 +79,7 @@ class PipelineSpec extends Specification {
 
       p.findInboundStage(classOf[Noop[Int]]).get should_== noop
       p.findInboundStage(noop.name).get should_== noop
-      noop.removeStage
+      noop.removeStage()
       p.findInboundStage(classOf[Noop[Int]]) must_== None
     }
 
@@ -91,7 +91,7 @@ class PipelineSpec extends Specification {
 
       p.findInboundStage(classOf[Noop[String]]).get should_== noop
       p.findInboundStage(noop.name).get should_== noop
-      noop.removeStage
+      noop.removeStage()
       p.findInboundStage(classOf[Noop[String]]) must_== None
     }
   }

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/DelayHead.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/DelayHead.scala
@@ -41,7 +41,7 @@ abstract class DelayHead[I](delay: Duration) extends HeadStage[I] {
   }
 
   override def readRequest(size: Int): Future[I] = {
-    val p = Promise[I]
+    val p = Promise[I]()
 
     rememberPromise(p)
 
@@ -58,7 +58,7 @@ abstract class DelayHead[I](delay: Duration) extends HeadStage[I] {
   }
 
   override def writeRequest(data: I): Future[Unit] = {
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     highresTimer.schedule(
       new Runnable {
         def run(): Unit = {

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/GatheringSeqHead.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/GatheringSeqHead.scala
@@ -25,7 +25,7 @@ class GatheringSeqHead[O](items: Seq[O]) extends SeqHead[O](items) {
   def go(): Future[Seq[O]] = {
     val p = this.synchronized {
       assert(result.isEmpty, s"Cannot use ${this.getClass.getSimpleName} more than once")
-      val p = Promise[Seq[O]]
+      val p = Promise[Seq[O]]()
       result = Some(p)
 
       sendInboundCommand(Command.Connected)

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/QuietTimeoutStageSpec.scala
@@ -33,7 +33,7 @@ class QuietTimeoutStageSpec extends TimeoutHelpers {
     "not timeout if the delay stage is removed" in {
       val pipe = makePipeline(2.seconds, 1.second)
       val f = pipe.channelRead()
-      pipe.findOutboundStage(classOf[TimeoutStageBase[ByteBuffer]]).get.removeStage
+      pipe.findOutboundStage(classOf[TimeoutStageBase[ByteBuffer]]).get.removeStage()
       val r = checkFuture(f, 5.second)
       pipe.closePipeline(None)
       r

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/SlowHead.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/SlowHead.scala
@@ -46,7 +46,7 @@ final class SlowHead[O] extends HeadStage[O] {
     synchronized {
       if (pendingRead.isDefined) Future.failed(new IllegalStateException("Read guard breached!"))
       else {
-        val p = Promise[O]
+        val p = Promise[O]()
         pendingRead = Some(p)
         p.future
       }
@@ -56,7 +56,7 @@ final class SlowHead[O] extends HeadStage[O] {
     synchronized {
       if (pendingWrite.isDefined) Future.failed(new IllegalStateException("Write guard breached!"))
       else {
-        val p = Promise[Unit]
+        val p = Promise[Unit]()
         pendingWrite = Some(Write(data, p))
         p.future
       }

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/StageSpec.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/StageSpec.scala
@@ -30,24 +30,24 @@ class StageSpec extends Specification {
   }
 
   "Support reads" in {
-    val leaf = regPipeline
+    val leaf = regPipeline()
     Await.result(leaf.channelRead(), 5.seconds) should_== 1
   }
 
   "Support writes" in {
-    val leaf = regPipeline
+    val leaf = regPipeline()
     Await.result(leaf.channelWrite(12), 5.seconds) should_== (())
   }
 
   "Support read timeouts" in {
-    val leaf = slowPipeline
+    val leaf = slowPipeline()
     Await.result(leaf.channelRead(1, 100.milli), 5000.milli) must throwA[TimeoutException]
 
     Await.result(leaf.channelRead(1, 10.seconds), 10.seconds) should_== 1
   }
 
   "Support write timeouts" in {
-    val leaf = slowPipeline
+    val leaf = slowPipeline()
     Await.result(leaf.channelWrite(1, 100.milli), 5000.milli) must throwA[TimeoutException]
 
     Await.result(leaf.channelWrite(1, 10.seconds), 10.seconds) should_== (())

--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/TestTailStages.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/TestTailStages.scala
@@ -19,7 +19,7 @@ class MapTail[A](f: A => A) extends TailStage[A] {
   override def name = "MapTail"
 
   def startLoop(): Future[Unit] = {
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     innerLoop(p)
     p.future
   }

--- a/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/BodyReader.scala
@@ -118,7 +118,7 @@ object BodyReader {
     require(max >= 0)
 
     val acc = new ArrayBuffer[ByteBuffer]
-    val p = Promise[ByteBuffer]
+    val p = Promise[ByteBuffer]()
 
     def go(bytes: Long): Unit =
       body().onComplete {

--- a/http/src/main/scala/org/http4s/blaze/http/ClientSessionManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/ClientSessionManagerImpl.scala
@@ -109,7 +109,7 @@ private final class ClientSessionManagerImpl(
       urlComposition: UrlComposition,
       id: ConnectionId): Future[HttpClientSession] = {
     logger.debug(s"Creating new session for id $id")
-    val p = Promise[HttpClientSession]
+    val p = Promise[HttpClientSession]()
 
     socketFactory.connect(urlComposition.getAddress).onComplete {
       case Failure(e) => p.tryFailure(e)

--- a/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/RouteAction.scala
@@ -58,7 +58,7 @@ object RouteAction {
 //          case _ => writer.close()
 //        }
 
-        val p = Promise[T#Finished]
+        val p = Promise[T#Finished]()
 
         // Have to do this nonsense because a recursive Future loop isn't safe until scala 2.12+
         def go(): Unit =

--- a/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerCodec.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http1/server/Http1ServerCodec.scala
@@ -55,7 +55,7 @@ private final class Http1ServerCodec(maxNonBodyBytes: Int, pipeline: TailStage[B
           val req = maybeGetRequest()
           if (req != null) Future.successful(req)
           else {
-            val p = Promise[HttpRequest]
+            val p = Promise[HttpRequest]()
             readAndGetRequest(p)
             p.future
           }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/ConnectionImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/ConnectionImpl.scala
@@ -37,7 +37,7 @@ private final class ConnectionImpl(
   private[this] def isClient = inboundStreamBuilder.isEmpty
 
   private[this] val logger = org.log4s.getLogger
-  private[this] val closedPromise = Promise[Unit]
+  private[this] val closedPromise = Promise[Unit]()
   private[this] val frameDecoder = new FrameDecoder(
     localSettings,
     new SessionFrameListener(
@@ -138,7 +138,7 @@ private final class ConnectionImpl(
   override def activeStreams: Int = streamManager.size
 
   override def ping(): Future[Duration] = {
-    val p = Promise[Duration]
+    val p = Promise[Duration]()
     serialExecutor.execute(new Runnable {
       def run(): Unit = {
         p.completeWith(pingManager.ping())

--- a/http/src/main/scala/org/http4s/blaze/http/http2/PingManager.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/PingManager.scala
@@ -31,7 +31,7 @@ private class PingManager(session: SessionCore) {
         // TODO: we can do a lot of cool things with pings by managing when they are written
         if (session.writeController.write(pingFrame)) {
           logger.debug(s"PING initiated at $time")
-          val p = Promise[Duration]
+          val p = Promise[Duration]()
           state = Pinging(time, p)
           p.future
         } else {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/SettingsDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/SettingsDecoder.scala
@@ -82,7 +82,7 @@ private[blaze] object SettingsDecoder {
             settings += Setting(id, value)
           }
 
-          SettingsFrame(Some(settings.result))
+          SettingsFrame(Some(settings.result()))
         }
       }
   }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamManagerImpl.scala
@@ -78,7 +78,7 @@ private final class StreamManagerImpl(
         ()
 
       case None =>
-        val p = Promise[Unit]
+        val p = Promise[Unit]()
         p.trySuccess(())
         drainingP = Some(p)
     }
@@ -234,7 +234,7 @@ private final class StreamManagerImpl(
           // Working around change to filterKeys in 2.13
         }
 
-        val p = Promise[Unit]
+        val p = Promise[Unit]()
         drainingP = Some(p)
         p.future
     }

--- a/http/src/main/scala/org/http4s/blaze/http/http2/StreamStateImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/StreamStateImpl.scala
@@ -62,7 +62,7 @@ private abstract class StreamStateImpl(session: SessionCore) extends StreamState
 
   override def readRequest(size: Int): Future[StreamFrame] = {
     val _ = size
-    val p = Promise[StreamFrame]
+    val p = Promise[StreamFrame]()
     // Move the work into the session executor
     session.serialExecutor.execute(new Runnable {
       override def run(): Unit = invokeStreamRead(p)
@@ -99,7 +99,7 @@ private abstract class StreamStateImpl(session: SessionCore) extends StreamState
       }
 
   final override def writeRequest(msg: StreamFrame): Future[Unit] = {
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     // Move the work into the session executor
     session.serialExecutor.execute(new Runnable {
       override def run(): Unit = invokeStreamWrite(msg, p)

--- a/http/src/main/scala/org/http4s/blaze/http/http2/WriteControllerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/WriteControllerImpl.scala
@@ -47,7 +47,7 @@ private final class WriteControllerImpl(
         FutureUnit
 
       case Flushing =>
-        val p = Promise[Unit]
+        val p = Promise[Unit]()
         state = Closing(p)
         p.future
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientPriorKnowledgeHandshaker.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientPriorKnowledgeHandshaker.scala
@@ -35,7 +35,7 @@ private[http] class ClientPriorKnowledgeHandshaker(
     flowStrategy: FlowStrategy,
     executor: ExecutionContext)
     extends PriorKnowledgeHandshaker[Http2ClientSession](localSettings) {
-  private[this] val session = Promise[Http2ClientSession]
+  private[this] val session = Promise[Http2ClientSession]()
 
   def clientSession: Future[Http2ClientSession] = session.future
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientSessionImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientSessionImpl.scala
@@ -46,7 +46,7 @@ private final class ClientSessionImpl(
 
   override def quality: Double = connection.quality
 
-  override def ping(): Future[Duration] = connection.ping
+  override def ping(): Future[Duration] = connection.ping()
 
   override def status: Status = connection.status
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/ClientStage.scala
@@ -57,7 +57,7 @@ private class ClientStage(request: HttpRequest) extends TailStage[StreamFrame] {
 
   override def name: String = "Http2ClientTail"
 
-  private[this] val _result = Promise[ReleaseableResponse]
+  private[this] val _result = Promise[ReleaseableResponse]()
 
   def result: Future[ReleaseableResponse] = _result.future
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/client/Http2ClientSessionManagerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/client/Http2ClientSessionManagerImpl.scala
@@ -115,7 +115,7 @@ private[http] class Http2ClientSessionManagerImpl(
   }
 
   protected def initialPipeline(head: HeadStage[ByteBuffer]): Future[Http2ClientSession] = {
-    val p = Promise[Http2ClientSession]
+    val p = Promise[Http2ClientSession]()
 
     def buildConnection(s: String): LeafBuilder[ByteBuffer] = {
       if (s != H2 && s != H2_14)

--- a/http/src/test/scala/org/http4s/blaze/http/endtoend/InfiniteSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/endtoend/InfiniteSpec.scala
@@ -38,7 +38,7 @@ class InfiniteSpec extends Specification {
               new RouteAction {
                 override def handle[T <: BodyWriter](responder: (HttpResponsePrelude) => T) = {
                   val writer = responder(HttpResponsePrelude(200, "OK", Nil))
-                  val p = Promise[T#Finished]
+                  val p = Promise[T#Finished]()
                   def go(): Unit =
                     writer
                       .write(

--- a/http/src/test/scala/org/http4s/blaze/http/endtoend/scaffolds/Http2ClientScaffold.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/endtoend/scaffolds/Http2ClientScaffold.scala
@@ -35,7 +35,7 @@ private[endtoend] class Http2ClientScaffold extends ClientScaffold(2, 0) {
     ) {
       override protected def initialPipeline(
           head: HeadStage[ByteBuffer]): Future[Http2ClientSession] = {
-        val p = Promise[Http2ClientSession]
+        val p = Promise[Http2ClientSession]()
 
         // TODO: we need a better model for these
         val localSettings = h2Settings.copy()

--- a/http/src/test/scala/org/http4s/blaze/http/http1/client/Http1ClientStageSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http1/client/Http1ClientStageSpec.scala
@@ -61,7 +61,7 @@ class Http1ClientStageSpec extends Specification {
       writes match {
         case Some(_) => Future.failed(new IllegalStateException())
         case None =>
-          val p = Promise[Unit]
+          val p = Promise[Unit]()
           writes = Some(Write(data, p))
           p.future
       }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/StreamStateImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/StreamStateImplSpec.scala
@@ -51,7 +51,7 @@ class StreamStateImplSpec extends Specification {
 
       val f = streamState.writeRequest(DataFrame(true, BufferTools.emptyBuffer))
 
-      tools.writeController.observedInterests.result must_== streamState :: Nil
+      tools.writeController.observedInterests.result() must_== streamState :: Nil
       tools.writeController.observedInterests.clear()
       f.isCompleted must beFalse
     }
@@ -62,7 +62,7 @@ class StreamStateImplSpec extends Specification {
 
       val f = streamState.writeRequest(DataFrame(true, BufferTools.emptyBuffer))
 
-      tools.writeController.observedInterests.result must_== streamState :: Nil
+      tools.writeController.observedInterests.result() must_== streamState :: Nil
       tools.writeController.observedInterests.clear()
       f.isCompleted must beFalse
 
@@ -76,7 +76,7 @@ class StreamStateImplSpec extends Specification {
 
       val f1 = streamState.writeRequest(DataFrame(true, BufferTools.emptyBuffer))
       f1.isCompleted must beFalse
-      tools.writeController.observedInterests.result must_== streamState :: Nil
+      tools.writeController.observedInterests.result() must_== streamState :: Nil
 
       val currentSize = tools.writeController.observedWrites.length
 

--- a/http/src/test/scala/org/http4s/blaze/http/http2/WriteControllerImplSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/WriteControllerImplSpec.scala
@@ -41,7 +41,7 @@ class WriteControllerImplSpec extends Specification {
       channelWrite(data :: Nil)
 
     override def channelWrite(data: collection.Seq[ByteBuffer]): Future[Unit] = {
-      val p = Promise[Unit]
+      val p = Promise[Unit]()
       written += Write(data, p)
       p.future
     }

--- a/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockHeadStage.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/http2/mocks/MockHeadStage.scala
@@ -20,7 +20,7 @@ private[http2] class MockHeadStage[T] extends HeadStage[T] {
   var error: Option[Throwable] = None
 
   override def readRequest(size: Int): Future[T] = {
-    val p = Promise[T]
+    val p = Promise[T]()
     reads += p
     p.future
   }
@@ -38,7 +38,7 @@ private[http2] class MockHeadStage[T] extends HeadStage[T] {
   }
 
   override def writeRequest(data: T): Future[Unit] = {
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     writes += data -> p
     p.future
   }

--- a/http/src/test/scala/org/http4s/blaze/http/parser/ResponseParser.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/parser/ResponseParser.scala
@@ -48,7 +48,7 @@ class ResponseParser extends Http1ClientParser {
       new String(bytes, StandardCharsets.ISO_8859_1)
     }
 
-    val headers = this.headers.result
+    val headers = this.headers.result()
 
     val status = this.code
 

--- a/http/src/test/scala/org/http4s/blaze/http/parser/ServerParserSpec.scala
+++ b/http/src/test/scala/org/http4s/blaze/http/parser/ServerParserSpec.scala
@@ -76,7 +76,7 @@ class ServerParserSpec extends Specification {
       if (h._2.length > 0) sb.append(": " + h._2)
       sb.append("\r\n")
     }.append("\r\n")
-      .result
+      .result()
 
   val headers = buildHeaderString(l_headers)
 
@@ -180,7 +180,7 @@ class ServerParserSpec extends Specification {
       p.parseLine(line)
       p.parseheaders(headers) should_== true
       p.getContentType should_== (EndOfContent.END)
-      p.h.result should_== (l_headers.map { case (a, b) => (a.trim, b.trim) })
+      p.h.result() should_== (l_headers.map { case (a, b) => (a.trim, b.trim) })
     }
 
     "Fail on non-ascii char in header name" in {
@@ -216,14 +216,14 @@ class ServerParserSpec extends Specification {
       val p = new Parser()
       p.parseheaders(hsStr) should_== true
       p.getContentType should_== (EndOfContent.END) // since the headers didn't indicate any content
-      p.h.result should_== List.fill(4)(("If-Modified-Since", ""))
+      p.h.result() should_== List.fill(4)(("If-Modified-Since", ""))
     }
 
     "need input on partial headers" in {
       val p = new Parser()
       p.parseHeaders(headers.substring(0, 20)) should_== false
       p.parseheaders(headers.substring(20)) should_== true
-      p.h.result should_== (l_headers.map { case (a, b) => (a.trim, b.trim) })
+      p.h.result() should_== (l_headers.map { case (a, b) => (a.trim, b.trim) })
     }
 
     "Parse a full request" in {
@@ -303,7 +303,7 @@ class ServerParserSpec extends Specification {
       p.parsecontent(b) should_!= null
       // two real messages
       p.parsecontent(b).remaining() should_== 0
-      p.h.result should_== (("Foo", "") :: Nil)
+      p.h.result() should_== (("Foo", "") :: Nil)
       p.sb.result() should_== (body + body + " again!")
 
       p.reset()
@@ -354,7 +354,7 @@ class ServerParserSpec extends Specification {
       while (!p.headersComplete() && !p.parseheaders(b))
         b.limit(b.limit() + 1)
 
-      p.h.clear
+      p.h.clear()
 
       p.contentComplete() should_== false
 
@@ -362,7 +362,7 @@ class ServerParserSpec extends Specification {
         p.parsecontent(b)
         if (b.limit() < blim) b.limit(b.limit() + 1)
       }
-      p.h.result should_== (("Foo", "") :: Nil)
+      p.h.result() should_== (("Foo", "") :: Nil)
       p.contentComplete() should_== true
       p.sb.result() should_== (body + body + " again!")
     }

--- a/project/BlazePlugin.scala
+++ b/project/BlazePlugin.scala
@@ -27,7 +27,7 @@ object BlazePlugin extends AutoPlugin {
   lazy val logbackClassic      = "ch.qos.logback"             %  "logback-classic"     % "1.2.3"
   lazy val twitterHPACK        = "com.twitter"                %  "hpack"               % "1.0.2"
   lazy val asyncHttpClient     = "org.asynchttpclient"        %  "async-http-client"   % "2.12.1"
-  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.9.0"
+  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.10.0-M1"
   lazy val scalacheck          = "org.scalacheck"             %% "scalacheck"          % "1.15.1"
   lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "4.10.5"
   lazy val specs2Mock          = "org.specs2"                 %% "specs2-mock"         % specs2.revision


### PR DESCRIPTION
Scala 2.13.3 warns on this, and Dotty (coming soon) enforces it.