### PR TITLE
Don't fail on inbound message

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -254,17 +254,13 @@ sealed trait Head[O] extends Stage {
   final def sendInboundCommand(cmd: InboundCommand): Unit = {
     logger.debug(s"Stage ${getClass.getSimpleName} sending inbound command: $cmd")
     val next = _nextStage
-    if (next != null)
+    if (next != null) {
       try next.inboundCommand(cmd)
       catch {
         case NonFatal(t) =>
           logger.error(t)("Exception caught when attempting inbound command")
           closePipeline(Some(t))
       }
-    else {
-      val msg = "Cannot send inbound command on disconnected stage"
-      val e = new Exception(msg)
-      throw e
     }
   }
 


### PR DESCRIPTION
This is my first attempt at a solution for https://github.com/http4s/http4s/issues/1256 . It turns out that the bug is actually benign and has only been observed to occur during connection shutdowns, so it should never actually cause any issues. Either way, people get understandably worried when they see exceptions, so we should try to clean that up.

The bug is really just a consequence of the fact that the Blaze pipeline is mutable and there is no synchronization over modifications to the pipeline. So for example, in the original issue, what's happening is that the `IdleTimeoutStage` is trying to send a message inbound, but its next stage is `null`, so it can't really continue. As far as I know, the only way this can happen is when a stage removes itself from the pipeline, but an upstream stage has sent it a message before the removal has been complete.

The quickest fix I can think of is to just acknowledge that the next stage might be null and don't do anything.

Tell me how bad of an idea this is, because I'm not really sure what the consequences are yet. I have a couple other ideas to fix this but this took the least effort.