### PR TITLE
Downgrade to log4s-1.9.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   lazy val logbackClassic      = "ch.qos.logback"             %  "logback-classic"     % "1.2.3"
   lazy val twitterHPACK        = "com.twitter"                %  "hpack"               % "1.0.2"
   lazy val asyncHttpClient     = "org.asynchttpclient"        %  "async-http-client"   % "2.12.2"
-  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.10.0-M3"
+  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.9.0"
   lazy val scalacheck          = "org.scalacheck"             %% "scalacheck"          % "1.15.2"
   lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "4.10.6"
   lazy val specs2Mock          = "org.specs2"                 %% "specs2-mock"         % specs2.revision


### PR DESCRIPTION
There's no reason to be on a milestone until we have Dotty support.