### PR TITLE
Use JDK platform APIs for ALPN negotiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 /.lib/
 
 *~
+/.bsp/
 /.ensime
 /.idea/
 /.idea_modules/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ in a unified way. blaze offers TCP socket server support for both NIO1 and NIO2,
 NIO1 tends to be the better performing technology for raw sockets.
 
 ## Getting started
-For a quick start, look in the examples project for some simple examples of HTTP, WebSocket, and a simple EchoServer. 
+For a quick start, look in the examples project for some simple examples of HTTP, WebSocket, and a simple EchoServer.
+
+### Requirements
+Blaze requires a modern, supported version of the JVM to build and run, as it relies on server APIs unavailable before
+[JDK8u252](https://webtide.com/jetty-alpn-java-8u252/). Any JDK newer than JDK8u252, including 9+ is supported.
 
 #### Important blaze behaviors
 * By default, read and write requests should be serialized either manually, or with a `SerializerStage`.

--- a/build.sbt
+++ b/build.sbt
@@ -92,10 +92,7 @@ lazy val http = Project("blaze-http", file("http"))
   .settings(commonSettings)
   .settings(
     // General Dependencies
-    libraryDependencies ++= Seq(
-      twitterHPACK,
-      alpn_api
-    ),
+    libraryDependencies += twitterHPACK,
     // Test Dependencies
     libraryDependencies ++= Seq(
       asyncHttpClient,

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,9 @@ lazy val http = Project("blaze-http", file("http"))
     ).map(_ % Test),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.blaze.http.http2.PingManager$PingState"),
-      ProblemFilters.exclude[MissingClassProblem]("org.http4s.blaze.http.http2.PingManager$PingState$")
+      ProblemFilters.exclude[MissingClassProblem]("org.http4s.blaze.http.http2.PingManager$PingState$"),
+      ProblemFilters.exclude[MissingClassProblem]("org.http4s.blaze.http.http2.client.ALPNClientSelector$ClientProvider"),
+      ProblemFilters.exclude[MissingClassProblem]("org.http4s.blaze.http.http2.server.ALPNServerSelector$ServerProvider")
     )
   ).dependsOn(core % "test->test;compile->compile")
 

--- a/build.sbt
+++ b/build.sbt
@@ -109,13 +109,10 @@ lazy val http = Project("blaze-http", file("http"))
   ).dependsOn(core % "test->test;compile->compile")
 
 lazy val examples = Project("blaze-examples",file("examples"))
-  .enablePlugins(AlpnBootPlugin)
   .enablePlugins(NoPublishPlugin)
   .settings(commonSettings)
   .settings(Revolver.settings)
-  .settings(
-    alpnBootModule := alpn_boot,
-  ).dependsOn(http)
+  .dependsOn(http)
 
 /* Helper Functions */
 

--- a/examples/src/main/scala/org/http4s/blaze/examples/http2/H2ClientExample.scala
+++ b/examples/src/main/scala/org/http4s/blaze/examples/http2/H2ClientExample.scala
@@ -24,11 +24,6 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 /** Examples which calls the Twitter or Google home pages using HTTP/2
-  *
-  * @note the Jetty ALPN boot library must have been loaded in order for
-  *       ALPN negotiation to happen. See the Jetty docs at
-  *       https://www.eclipse.org/jetty/documentation/9.3.x/alpn-chapter.html
-  *       for more information.
   */
 object H2ClientTwitterExample extends H2ClientExample(20, 30.seconds)
 

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ALPNServerSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ALPNServerSelector.scala
@@ -43,12 +43,8 @@ final class ALPNServerSelector(
     val available = protocols.asScala.toList
     logger.debug("Available protocols: " + available)
     val s = selector(available.toSet)
-    selected = Some(s)
     s
   }
-
-  @volatile
-  private var selected: Option[String] = None
 
   override def name: String = "PipelineSelector"
 
@@ -64,7 +60,7 @@ final class ALPNServerSelector(
 
   private def selectPipeline(): Unit =
     try {
-      val protocol = selected.getOrElse(selector(Set.empty))
+      val protocol = Option(engine.getApplicationProtocol()).getOrElse(selector(Set.empty))
       val b = builder(protocol)
       this.replaceTail(b, true)
       ()

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerSelector.scala
@@ -39,12 +39,7 @@ object ServerSelector {
         case _ => LeafBuilder(http1xStage(service, config))
       }
 
-    def selector(protocols: Set[String]): String =
-      if (protocols(H2)) H2
-      else if (protocols(H2_14)) H2_14
-      else HTTP_1_1
-
-    new ALPNServerSelector(engine, selector, builder)
+    new ALPNServerSelector(engine, List(H2, H2_14, HTTP_1_1), HTTP_1_1, builder)
   }
 
   private def http1xStage(

--- a/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerSelector.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/server/ServerSelector.scala
@@ -39,7 +39,12 @@ object ServerSelector {
         case _ => LeafBuilder(http1xStage(service, config))
       }
 
-    new ALPNServerSelector(engine, List(H2, H2_14, HTTP_1_1), HTTP_1_1, builder)
+    def selector(protocols: Set[String]): String =
+      if (protocols(H2)) H2
+      else if (protocols(H2_14)) H2_14
+      else HTTP_1_1
+
+    new ALPNServerSelector(engine, selector, builder)
   }
 
   private def http1xStage(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,4 @@ object Dependencies {
   lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "4.10.6"
   lazy val specs2Mock          = "org.specs2"                 %% "specs2-mock"         % specs2.revision
   lazy val specs2Scalacheck    = "org.specs2"                 %% "specs2-scalacheck"   % specs2.revision
-  // Needed for Http2 support until implemented in the JDK
-  lazy val alpn_api            = "org.eclipse.jetty.alpn"     % "alpn-api"             % "1.1.3.v20160715"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,4 @@ object Dependencies {
   lazy val specs2Scalacheck    = "org.specs2"                 %% "specs2-scalacheck"   % specs2.revision
   // Needed for Http2 support until implemented in the JDK
   lazy val alpn_api            = "org.eclipse.jetty.alpn"     % "alpn-api"             % "1.1.3.v20160715"
-  // Note that the alpn_boot version is JVM version specific. Check the docs if getting weird errors.
-  // Also note that only java8 and above has the require cipher suite for http2.
-  lazy val alpn_boot           = "org.eclipse.jetty"          % "jetty-alpn-openjdk8-client" % "9.4.36.v20210114"
 }


### PR DESCRIPTION
Before (curl output):
```
vasil@vasil-mac ~ % curl -v -k https://127.0.0.1:8443/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server did not agree to a protocol                    ### <----------------------------------------
* Server certificate:
*  subject: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=Unknown
*  start date: Dec  7 21:49:01 2014 GMT
*  expire date: Dec  2 21:49:01 2015 GMT
*  issuer: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=Unknown
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
> GET / HTTP/1.1
> Host: 127.0.0.1:8443
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 200 OK                    ### <----------------------------------------
< content-type: text/plain; charset=utf-8
< date: Fri, 16 Apr 2021 13:07:16 GMT
< content-length: 104
< 
Hello world!
Path: /
Headers
["Host", "127.0.0.1:8443"]
["User-Agent", "curl/7.64.1"]
["Accept", "*/*"]
* Connection #0 to host 127.0.0.1 left intact
* Closing connection 0
```

After (curl output):
```
vasil@vasil-mac ~ % curl -v -k https://127.0.0.1:8443/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2                    ### <----------------------------------------
* Server certificate:
*  subject: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=Unknown
*  start date: Dec  7 21:49:01 2014 GMT
*  expire date: Dec  2 21:49:01 2015 GMT
*  issuer: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=Unknown
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* Using HTTP2, server supports multi-use                    ### <----------------------------------------
* Connection state changed (HTTP/2 confirmed)                    ### <----------------------------------------
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7feeaa00c400)
> GET / HTTP/2                    ### <----------------------------------------
> Host: 127.0.0.1:8443
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 200                     ### <----------------------------------------
< content-length: 77
< content-type: text/plain; charset=utf-8
< 
Hello world!
Path: /
Headers
["user-agent", "curl/7.64.1"]
["accept", "*/*"]
* Connection #0 to host 127.0.0.1 left intact
* Closing connection 0
```