### PR TITLE
Upgrade Scala to 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.13, 2.13.5, 3.0.0-RC2, 3.0.0-RC3]
+        scala: [2.12.13, 2.13.5, 3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -13,15 +13,15 @@ ThisBuild / versionIntroduced := Map(
   "3.0.0-RC3" -> "0.15.0"
 )
 
-ThisBuild / crossScalaVersions := Seq("2.12.13", "2.13.5", "3.0.0-RC2", "3.0.0-RC3")
+ThisBuild / crossScalaVersions := Seq("2.12.13", "2.13.5", "3.0.0")
 ThisBuild / scalaVersion := crossScalaVersions.value.filter(_.startsWith("2.")).last
 
 lazy val commonSettings = Seq(
   description := "NIO Framework for Scala",
-  scalacOptions in Test ~= (_.filterNot(Set("-Ywarn-dead-code", "-Wdead-code"))), // because mockito
-  scalacOptions in (Compile, doc) += "-no-link-warnings",
-  unmanagedSourceDirectories in Compile ++= {
-    (unmanagedSourceDirectories in Compile).value.map { dir =>
+  Test / scalacOptions ~= (_.filterNot(Set("-Ywarn-dead-code", "-Wdead-code"))), // because mockito
+  Compile / doc / scalacOptions += "-no-link-warnings",
+  Compile / unmanagedSourceDirectories ++= {
+    (Compile / unmanagedSourceDirectories).value.map { dir =>
       val sv = scalaVersion.value
       CrossVersion.binaryScalaVersion(sv) match {
         case "2.11" | "2.12" => file(dir.getPath ++ "-2.11-2.12")
@@ -29,7 +29,7 @@ lazy val commonSettings = Seq(
       }
     }
   },
-  fork in run := true,
+  run / fork := true,
   developers ++= List(
     Developer("bryce-anderson"       , "Bryce L. Anderson"     , "bryce.anderson22@gamil.com"       , url("https://github.com/bryce-anderson")),
     Developer("rossabaker"           , "Ross A. Baker"         , "ross@rossabaker.com"              , url("https://github.com/rossabaker")),
@@ -72,8 +72,8 @@ lazy val core = Project("blaze-core", file("core"))
   .settings(
     libraryDependencies ++= Seq(log4s),
     libraryDependencies ++= Seq(
-      specs2.withDottyCompat(scalaVersion.value),
-      specs2Mock.withDottyCompat(scalaVersion.value),
+      specs2.cross(CrossVersion.for3Use2_13),
+      specs2Mock.cross(CrossVersion.for3Use2_13),
       logbackClassic
     ).map(_ % Test),
     buildInfoPackage := "org.http4s.blaze",
@@ -98,8 +98,8 @@ lazy val http = Project("blaze-http", file("http"))
     // Test Dependencies
     libraryDependencies ++= Seq(
       asyncHttpClient,
-      scalacheck.withDottyCompat(scalaVersion.value),
-      specs2Scalacheck.withDottyCompat(scalaVersion.value)
+      scalacheck.cross(CrossVersion.for3Use2_13),
+      specs2Scalacheck.cross(CrossVersion.for3Use2_13)
     ).map(_ % Test),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[MissingClassProblem]("org.http4s.blaze.http.http2.PingManager$PingState"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   lazy val logbackClassic      = "ch.qos.logback"             %  "logback-classic"     % "1.2.3"
   lazy val twitterHPACK        = "com.twitter"                %  "hpack"               % "1.0.2"
   lazy val asyncHttpClient     = "org.asynchttpclient"        %  "async-http-client"   % "2.12.3"
-  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.10.0-M7"
+  lazy val log4s               = "org.log4s"                  %% "log4s"               % "1.10.0-RC1"
   lazy val scalacheck          = "org.scalacheck"             %% "scalacheck"          % "1.15.4"
   lazy val specs2              = "org.specs2"                 %% "specs2-core"         % "4.11.0"
   lazy val specs2Mock          = "org.specs2"                 %% "specs2-mock"         % specs2.revision

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,6 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.2")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 addSbtPlugin("org.http4s" %% "sbt-http4s-org" % "0.7.5")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+
+// Temporary workaround
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
Same issue with sbt-dotty as in vault and case-insensitive.

Additionally, a 3.0 compatible version of log4s is still missing: https://github.com/Log4s/log4s/pull/76