### PR TITLE
Add package private isAlive and specific Exception type

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -18,7 +18,7 @@ package org.http4s.blaze.util
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
-import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.control.NonFatal
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import org.http4s.blaze.util.TickWheelExecutor.DefaultWheelSize
@@ -274,9 +274,7 @@ class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, val tick: Duration = 
 }
 
 object TickWheelExecutor {
-  object AlreadyShutdownException
-      extends RuntimeException("TickWheelExecutor is shutdown")
-      with NoStackTrace
+  object AlreadyShutdownException extends RuntimeException("TickWheelExecutor is shutdown")
 
   /** Default size of the hash wheel */
   val DefaultWheelSize = 512


### PR DESCRIPTION
The motivation for this is to make it possible to not submit a new task when the TickWheelExecutor is being shutdown.
This mostly happens at the end, so we just want to make sure we dont submit or fail with an exception.