### PR TITLE
Freshen the JDK in the Nix shell

### DIFF
--- a/nix/nixpkgs-version.json
+++ b/nix/nixpkgs-version.json
@@ -1,10 +1,7 @@
 {
-  "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "84d74ae9c9cbed73274b8e4e00be14688ffc93fe",
-  "date": "2020-09-26T18:54:09-07:00",
-  "path": "/nix/store/lkgidjs90m435m46zqyxa1sphsqfj6ld-nixpkgs-channels",
-  "sha256": "0ww70kl08rpcsxb9xdx8m48vz41dpss4hh3vvsmswll35l158x0v",
-  "fetchSubmodules": false,
-  "deepClone": false,
-  "leaveDotGit": false
+    "owner": "nixos",
+    "repo": "nixpkgs",
+    "rev": "61290574123116a36225811f3ea6a7cfdf0fd17b",
+    "sha256": "1vwcjnx3nf9cw7xvi92lrd46k7sycvq9m1dfgq2myw02z5zklv06",
+    "fetchSubmodules": true
 }


### PR DESCRIPTION
I couldn't build on a Mac with the old version.  It was missing things on SSLEngine.