### PR TITLE
Set `githubWorkflowPublishTargetBranches` only once in the build.sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -76,11 +76,8 @@ ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 
 // currently only publishing tags
 ThisBuild / githubWorkflowPublishTargetBranches :=
-  Seq(RefPredicate.StartsWith(Ref.Tag("v")))
+  Seq(RefPredicate.StartsWith(Ref.Tag("v")), RefPredicate.Equals(Ref.Branch("main")))
 
-ThisBuild / githubWorkflowPublishTargetBranches := Seq(
-  RefPredicate.Equals(Ref.Branch("main"))
-)
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("validate-ci"))
 )


### PR DESCRIPTION
This tries to fix #555. It seems that the `githubWorkflowPublishTargetBranches` should be set only once. However, I'm not sure that it's the root of the problem.