### PR TITLE
Update `sbt-http4s-org`

### DIFF
--- a/core/src/main/scala/org/http4s/blaze/channel/ServerChannel.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/ServerChannel.scala
@@ -122,7 +122,7 @@ abstract class ServerChannel extends Closeable { self =>
       try hook()
       catch {
         case NonFatal(t) =>
-          logger.error(t)(s"Exception occurred during Channel shutdown.")
+          logger.error(t)("Exception occurred during Channel shutdown.")
       } finally
         // If we're the last hook to run, we notify any listeners
         if (countdown.decrementAndGet() == 0)

--- a/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio1/SelectorLoop.scala
@@ -136,7 +136,7 @@ final class SelectorLoop(
           try {
             // We place all this noise in the `try` since pretty
             // much every method on the `SelectableChannel` can throw.
-            require(!ch.selectableChannel.isBlocking, s"Can only register non-blocking channels")
+            require(!ch.selectableChannel.isBlocking, "Can only register non-blocking channels")
             val key = ch.selectableChannel.register(selector, 0)
             val head = mkStage(key)
             key.attach(head)

--- a/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
+++ b/core/src/main/scala/org/http4s/blaze/channel/nio2/ByteBufferHead.scala
@@ -134,7 +134,7 @@ private[nio2] final class ByteBufferHead(channel: AsynchronousSocketChannel, buf
 
     cause match {
       case Some(t) => logger.error(t)("NIO2 channel closed with error")
-      case None => logger.debug(s"doClosePipeline(None)")
+      case None => logger.debug("doClosePipeline(None)")
     }
 
     if (needsClose)

--- a/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/Stages.scala
@@ -59,7 +59,7 @@ sealed trait Stage {
     * misbehaving stages. It is therefore recommended that the method be idempotent.
     */
   protected def stageStartup(): Unit =
-    logger.debug(s"Starting up.")
+    logger.debug("Starting up.")
 
   /** Shuts down the stage, deallocating resources, etc.
     *
@@ -72,7 +72,7 @@ sealed trait Stage {
     * idempotent.
     */
   protected def stageShutdown(): Unit =
-    logger.debug(s"Shutting down.")
+    logger.debug("Shutting down.")
 
   /** Handle basic startup and shutdown commands.
     *

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/SSLStage.scala
@@ -168,7 +168,7 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
     val results = handshakeQueue.result()
     handshakeQueue.clear()
     if (results.isEmpty)
-      logger.error(t)(s"Handshake failure with no pending results")
+      logger.error(t)("Handshake failure with no pending results")
     else
       results.foreach {
         case DelayedRead(_, p) => p.failure(t)
@@ -200,7 +200,7 @@ final class SSLStage(engine: SSLEngine, maxWrite: Int = 1024 * 1024)
               }(serialExec)
 
             case Status.CLOSED => // happens if the handshake fails for some reason
-              handshakeFailure(new SSLException(s"SSL Closed"))
+              handshakeFailure(new SSLException("SSL Closed"))
 
             case Status.BUFFER_OVERFLOW =>
               handshakeFailure(util.bug(s"Unexpected status: ${Status.BUFFER_OVERFLOW}"))

--- a/core/src/main/scala/org/http4s/blaze/pipeline/stages/monitors/IntervalConnectionMonitor.scala
+++ b/core/src/main/scala/org/http4s/blaze/pipeline/stages/monitors/IntervalConnectionMonitor.scala
@@ -85,7 +85,7 @@ class IntervalConnectionMonitor(val interval: Duration) extends ConnectionMonito
         if (math.max(itotal, ototal) > 1024.0 * mb) (1024.0 * mb, "GB")
         else (mb, "MB")
 
-      s"""                 Mean (%s/s)     Total (%s)
+      """                 Mean (%s/s)     Total (%s)
          |Inbound bytes    %11.3f     %10.3f
          |Outbound bytes   %11.3f     %10.3f
          |

--- a/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
+++ b/core/src/main/scala/org/http4s/blaze/util/TickWheelExecutor.scala
@@ -66,7 +66,7 @@ class TickWheelExecutor(wheelSize: Int = DefaultWheelSize, val tick: Duration = 
   // ///////////////////////////////////////////////////
   // new Thread that actually runs the execution.
 
-  private val thread = new Thread(s"blaze-tick-wheel-executor") {
+  private val thread = new Thread("blaze-tick-wheel-executor") {
     override def run(): Unit =
       cycle(System.nanoTime())
   }

--- a/examples/src/main/scala/com/example/http4s/ExampleService.scala
+++ b/examples/src/main/scala/com/example/http4s/ExampleService.scala
@@ -109,7 +109,7 @@ class ExampleService[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
                 val sum = s.split(' ').filter(_.nonEmpty).map(_.trim.toInt).sum
                 Ok(sum.toString)
 
-              case None => BadRequest(s"Invalid data: " + data)
+              case None => BadRequest("Invalid data: " + data)
             }
           }
           .handleErrorWith { // We can handle errors using effect methods

--- a/http/src/main/scala/org/http4s/blaze/http/http2/ConnectionImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/ConnectionImpl.scala
@@ -189,7 +189,7 @@ private final class ConnectionImpl(
       }
 
       streamManager.forceClose(http2Ex) // Fail hard
-      sendGoAway(http2Ex.getOrElse(Http2Exception.NO_ERROR.goaway(s"No Error")))
+      sendGoAway(http2Ex.getOrElse(Http2Exception.NO_ERROR.goaway("No Error")))
       writeController
         .close()
         .onComplete { _ =>

--- a/http/src/main/scala/org/http4s/blaze/http/http2/FrameDecoder.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/FrameDecoder.scala
@@ -51,7 +51,7 @@ private class FrameDecoder(localSettings: Http2Settings, listener: FrameListener
       Error(PROTOCOL_ERROR.goaway(msg))
     } else if (frameType == FrameTypes.CONTINUATION && !listener.inHeaderSequence)
       // Received a CONTINUATION without preceding HEADERS or PUSH_PROMISE frames
-      Error(PROTOCOL_ERROR.goaway(s"Received CONTINUATION frame outside of a HEADERS sequence"))
+      Error(PROTOCOL_ERROR.goaway("Received CONTINUATION frame outside of a HEADERS sequence"))
     else if (buffer.remaining < len) { // We still don't have a full frame
       buffer.reset()
       BufferUnderflow
@@ -289,7 +289,7 @@ private class FrameDecoder(localSettings: Http2Settings, listener: FrameListener
       if (size != 0) listener.onWindowUpdateFrame(streamId, size)
       else
         Error { // never less than 0 due to the mask above
-          val msg = s"WINDOW_UPDATE with invalid update size 0"
+          val msg = "WINDOW_UPDATE with invalid update size 0"
           if (streamId == 0)
             PROTOCOL_ERROR.goaway(msg)
           else
@@ -304,7 +304,7 @@ private class FrameDecoder(localSettings: Http2Settings, listener: FrameListener
       flags: Byte
   ): Result =
     if (streamId == 0) {
-      val msg = s"CONTINUATION frame with invalid stream dependency on 0x0"
+      val msg = "CONTINUATION frame with invalid stream dependency on 0x0"
       Error(PROTOCOL_ERROR.goaway(msg))
     } else
       listener.onContinuationFrame(streamId, Flags.END_HEADERS(flags), buffer.slice())

--- a/http/src/main/scala/org/http4s/blaze/http/http2/FrameSerializer.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/FrameSerializer.scala
@@ -139,7 +139,7 @@ private[http2] object FrameSerializer {
 
   def mkRstStreamFrame(streamId: Int, errorCode: Long): ByteBuffer = {
     require(0 < streamId, "Invalid RST_STREAM stream id")
-    require(0 <= errorCode && errorCode <= Masks.INT32, s"Invalid error code")
+    require(0 <= errorCode && errorCode <= Masks.INT32, "Invalid error code")
 
     val payloadSize = 4
     val buffer = BufferTools.allocate(HeaderSize + payloadSize)

--- a/http/src/main/scala/org/http4s/blaze/http/http2/HeaderAggregatingFrameListener.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/HeaderAggregatingFrameListener.scala
@@ -102,7 +102,7 @@ private abstract class HeaderAggregatingFrameListener(
     if (inHeaderSequence)
       Error(
         PROTOCOL_ERROR.goaway(
-          s"Received HEADERS frame while in in headers sequence. Stream id " +
+          "Received HEADERS frame while in in headers sequence. Stream id " +
             FrameDecoder.hexStr(streamId)
         )
       )
@@ -146,7 +146,7 @@ private abstract class HeaderAggregatingFrameListener(
       buffer: ByteBuffer
   ): Result =
     if (hInfo.streamId != streamId) {
-      val msg = s"Invalid CONTINUATION frame: stream Id's don't match. " +
+      val msg = "Invalid CONTINUATION frame: stream Id's don't match. " +
         s"Expected ${hInfo.streamId}, received $streamId"
       Error(PROTOCOL_ERROR.goaway(msg))
     } else {

--- a/http/src/main/scala/org/http4s/blaze/http/http2/PriorKnowledgeHandshaker.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/PriorKnowledgeHandshaker.scala
@@ -66,7 +66,7 @@ abstract class PriorKnowledgeHandshaker[T](localSettings: ImmutableHttp2Settings
 
     def insufficientData = {
       logger.debug(
-        s"Insufficient data. Current representation: " +
+        "Insufficient data. Current representation: " +
           BufferTools.hexString(acc, 256)
       )
       channelRead().flatMap(buff => readSettings(BufferTools.concatBuffers(acc, buff)))
@@ -81,7 +81,7 @@ abstract class PriorKnowledgeHandshaker[T](localSettings: ImmutableHttp2Settings
           "While waiting for initial settings frame, encountered frame of " +
             s"size $size exceeded MAX_FRAME_SIZE (${localSettings.maxFrameSize})"
         )
-        logger.info(ex)(s"Received SETTINGS frame that was to large")
+        logger.info(ex)("Received SETTINGS frame that was to large")
         sendGoAway(ex)
 
       case Some(frameSize) if acc.remaining < frameSize =>
@@ -101,20 +101,20 @@ abstract class PriorKnowledgeHandshaker[T](localSettings: ImmutableHttp2Settings
             remoteSettings.updateSettings(newSettings) match {
               case None =>
                 logger.debug(
-                  s"Successfully received settings frame. Current " +
+                  "Successfully received settings frame. Current " +
                     s"remote settings: $remoteSettings"
                 )
                 sendSettingsAck().map(_ => remoteSettings -> acc)
 
               case Some(ex) =>
-                logger.info(ex)(s"Received SETTINGS frame but failed to update.")
+                logger.info(ex)("Received SETTINGS frame but failed to update.")
                 channelWrite(FrameSerializer.mkGoAwayFrame(0, ex)).flatMap { _ =>
                   Future.failed(ex)
                 }
             }
 
           case Right(SettingsFrame(None)) => // was an ack! This is a PROTOCOL_ERROR
-            logger.info(s"Received a SETTINGS ack frame which is a protocol error. Shutting down.")
+            logger.info("Received a SETTINGS ack frame which is a protocol error. Shutting down.")
             val ex = Http2Exception.PROTOCOL_ERROR.goaway(
               "Received a SETTINGS ack before receiving remote settings"
             )

--- a/http/src/main/scala/org/http4s/blaze/http/http2/WriteControllerImpl.scala
+++ b/http/src/main/scala/org/http4s/blaze/http/http2/WriteControllerImpl.scala
@@ -134,7 +134,7 @@ private final class WriteControllerImpl(
         bytesToWrite += addBuffs(toWrite, data)
       } catch {
         case NonFatal(t) =>
-          logger.error(t)(s"Unhandled exception performing stream write operation")
+          logger.error(t)("Unhandled exception performing stream write operation")
       }
 
     logger.debug(s"Flushing $bytesToWrite to the wire")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
-addSbtPlugin("org.http4s" %% "sbt-http4s-org" % "0.14.2")
+addSbtPlugin("org.http4s" %% "sbt-http4s-org" % "0.14.3")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
To sum up things about Scalafix in blaze - it looks like scalafix has updated together with `RedundantSyntax` rule, which we use in old blaze modules. The diff is tiny, so I don't think we should do some workarounds here.