### PR TITLE
Make sbt recognise the names of the http4s-* projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p blaze-client/target blaze-server/target target examples/target http/target blaze-core/target core/target testkit/target project/target
+        run: mkdir -p blaze-client/target target blaze-server/target examples/target http/target core/target blaze-core/target testkit/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar blaze-client/target blaze-server/target target examples/target http/target blaze-core/target core/target testkit/target project/target
+        run: tar cf targets.tar blaze-client/target target blaze-server/target examples/target http/target core/target blaze-core/target testkit/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -128,10 +128,8 @@ lazy val http = Project("blaze-http", file("http"))
   )
   .dependsOn(testkit % Test, core % "test->test;compile->compile")
 
-lazy val blazeCore = project
-  .in(file("blaze-core"))
+lazy val blazeCore = Project("http4s-blaze-core", file("blaze-core"))
   .settings(
-    name := "http4s-blaze-core",
     description := "Base library for binding blaze to http4s clients and servers",
     startYear := Some(2014),
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
@@ -174,10 +172,8 @@ lazy val blazeCore = project
   )
   .dependsOn(http)
 
-lazy val blazeServer = project
-  .in(file("blaze-server"))
+lazy val blazeServer = Project("http4s-blaze-server", file("blaze-server"))
   .settings(
-    name := "http4s-blaze-server",
     description := "blaze implementation for http4s servers",
     startYear := Some(2014),
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
@@ -238,10 +234,8 @@ lazy val blazeServer = project
   )
   .dependsOn(blazeCore % "compile;test->test")
 
-lazy val blazeClient = project
-  .in(file("blaze-client"))
+lazy val blazeClient = Project("http4s-blaze-client", file("blaze-client"))
   .settings(
-    name := "http4s-blaze-client",
     description := "blaze implementation for http4s clients",
     startYear := Some(2014),
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,


### PR DESCRIPTION
Before:
```
% sbt projects
...
[info]   * blaze
[info]     blaze-core
[info]     blaze-examples
[info]     blaze-http
[info]     blaze-testkit
[info]     blazeClient
[info]     blazeCore
[info]     blazeServer
```

After:
```
% sbt projects
...
[info]   * blaze
[info]     blaze-core
[info]     blaze-examples
[info]     blaze-http
[info]     blaze-testkit
[info]     http4s-blaze-client
[info]     http4s-blaze-core
[info]     http4s-blaze-server
```