### PR TITLE
Fix ScalaStewart reformatting build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ lazy val blazeCore = Project("http4s-blaze-core", file("blaze-core"))
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-core" % http4sVersion,
       "org.typelevel" %% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
-      logbackClassic % Test
+      logbackClassic % Test,
     ),
     mimaBinaryIssueFilters := {
       if (tlIsScala3.value)

--- a/build.sbt
+++ b/build.sbt
@@ -23,20 +23,20 @@ ThisBuild / developers ++= List(
     "bryce-anderson",
     "Bryce L. Anderson",
     "bryce.anderson22@gamil.com",
-    url("https://github.com/bryce-anderson")
+    url("https://github.com/bryce-anderson"),
   ),
   Developer(
     "rossabaker",
     "Ross A. Baker",
     "ross@rossabaker.com",
-    url("https://github.com/rossabaker")
+    url("https://github.com/rossabaker"),
   ),
   Developer(
     "ChristopherDavenport",
     "Christopher Davenport",
     "chris@christopherdavenport.tech",
-    url("https://github.com/ChristopherDavenport")
-  )
+    url("https://github.com/ChristopherDavenport"),
+  ),
 )
 ThisBuild / startYear := Some(2014)
 
@@ -55,7 +55,7 @@ lazy val commonSettings = Seq(
   },
   run / fork := true,
   scalafmtConfig := file(".scalafmt.blaze.conf"),
-  scalafixConfig := Some(file(".scalafix.blaze.conf"))
+  scalafixConfig := Some(file(".scalafix.blaze.conf")),
 )
 
 // currently only publishing tags
@@ -65,7 +65,7 @@ ThisBuild / githubWorkflowPublishTargetBranches :=
 ThisBuild / githubWorkflowBuild ++= Seq(
   WorkflowStep.Sbt(
     List("${{ matrix.ci }}", "javafmtCheckAll"),
-    name = Some("Check Java formatting")
+    name = Some("Check Java formatting"),
   )
 )
 
@@ -74,6 +74,7 @@ lazy val blaze = project
   .enablePlugins(Http4sOrgPlugin)
   .enablePlugins(NoPublishPlugin)
   .settings(commonSettings)
+  .settings(scalafmtConfig := file(".scalafmt.conf"))
   .aggregate(core, http, blazeCore, blazeServer, blazeClient, examples)
 
 lazy val testkit = Project("blaze-testkit", file("testkit"))
@@ -93,7 +94,7 @@ lazy val core = Project("blaze-core", file("core"))
     buildInfoKeys := Seq[BuildInfoKey](
       version,
       scalaVersion,
-      git.gitHeadCommit
+      git.gitHeadCommit,
     ),
     buildInfoOptions += BuildInfoOption.BuildTime,
     mimaBinaryIssueFilters ++= Seq(
@@ -101,7 +102,7 @@ lazy val core = Project("blaze-core", file("core"))
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.blaze.channel.nio1.NIO1SocketServerGroup.this"
       )
-    )
+    ),
   )
   .dependsOn(testkit % Test)
 
@@ -123,8 +124,8 @@ lazy val http = Project("blaze-http", file("http"))
       ),
       ProblemFilters.exclude[MissingClassProblem](
         "org.http4s.blaze.http.http2.server.ALPNServerSelector$ServerProvider"
-      )
-    )
+      ),
+    ),
   )
   .dependsOn(testkit % Test, core % "test->test;compile->compile")
 
@@ -137,7 +138,7 @@ lazy val blazeCore = project
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-core" % http4sVersion,
-      "org.typelevel" %% "munit-cats-effect-3" % munitCatsEffectVersion % Test
+      "org.typelevel" %% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
     ),
     mimaBinaryIssueFilters := {
       if (tlIsScala3.value)
@@ -166,11 +167,11 @@ lazy val blazeCore = project
           ProblemFilters
             .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.IdentityWriter.this"),
           ProblemFilters
-            .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.IdentityWriter.ec")
+            .exclude[DirectMissingMethodProblem]("org.http4s.blazecore.util.IdentityWriter.ec"),
         )
       else Seq.empty
     },
-    Test / scalafixConfig := Some(file(".scalafix.test.conf"))
+    Test / scalafixConfig := Some(file(".scalafix.test.conf")),
   )
   .dependsOn(http)
 
@@ -183,7 +184,7 @@ lazy val blazeServer = project
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-server" % http4sVersion,
-      "org.http4s" %% "http4s-dsl" % http4sVersion % Test
+      "org.http4s" %% "http4s-dsl" % http4sVersion % Test,
     ),
     mimaBinaryIssueFilters := Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem](
@@ -213,7 +214,7 @@ lazy val blazeServer = project
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.BlazeServerBuilder.this"),
       ProblemFilters
-        .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.WebSocketDecoder.this")
+        .exclude[DirectMissingMethodProblem]("org.http4s.blaze.server.WebSocketDecoder.this"),
     ) ++ {
       if (tlIsScala3.value)
         Seq(
@@ -230,11 +231,11 @@ lazy val blazeServer = project
           ),
           ProblemFilters.exclude[ReversedMissingMethodProblem](
             "org.http4s.blaze.server.WebSocketSupport.webSocketKey"
-          )
+          ),
         )
       else Seq.empty,
     },
-    Test / scalafixConfig := Some(file(".scalafix.test.conf"))
+    Test / scalafixConfig := Some(file(".scalafix.test.conf")),
   )
   .dependsOn(blazeCore % "compile;test->test")
 
@@ -247,7 +248,7 @@ lazy val blazeClient = project
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-client" % http4sVersion,
-      "org.http4s" %% "http4s-client-testkit" % http4sVersion % Test
+      "org.http4s" %% "http4s-client-testkit" % http4sVersion % Test,
     ),
     mimaBinaryIssueFilters ++= Seq(
       // private constructor
@@ -322,7 +323,7 @@ lazy val blazeClient = project
       ProblemFilters
         .exclude[IncompatibleResultTypeProblem]("org.http4s.blaze.client.Connection.isRecyclable"),
       ProblemFilters
-        .exclude[ReversedMissingMethodProblem]("org.http4s.blaze.client.Connection.isRecyclable")
+        .exclude[ReversedMissingMethodProblem]("org.http4s.blaze.client.Connection.isRecyclable"),
     ) ++ {
       if (tlIsScala3.value)
         Seq(
@@ -332,7 +333,7 @@ lazy val blazeClient = project
         )
       else Seq.empty
     },
-    Test / scalafixConfig := Some(file(".scalafix.test.conf"))
+    Test / scalafixConfig := Some(file(".scalafix.test.conf")),
   )
   .dependsOn(blazeCore % "compile;test->test")
 
@@ -344,9 +345,9 @@ lazy val examples = Project("blaze-examples", file("examples"))
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-dsl" % http4sVersion,
       "org.http4s" %% "http4s-circe" % http4sVersion,
-      "io.circe" %% "circe-generic" % "0.14.2"
+      "io.circe" %% "circe-generic" % "0.14.2",
     ),
-    Test / scalafixConfig := Some(file(".scalafix.test.conf"))
+    Test / scalafixConfig := Some(file(".scalafix.test.conf")),
   )
   .dependsOn(blazeServer, blazeClient)
 
@@ -355,5 +356,5 @@ lazy val examples = Project("blaze-examples", file("examples"))
 // use it in the local development process
 addCommandAlias(
   "validate",
-  ";scalafmtCheckAll ;scalafmtSbtCheck ;javafmtCheckAll ;+test:compile ;test ;unusedCompileDependenciesTest ;mimaReportBinaryIssues"
+  ";scalafmtCheckAll ;scalafmtSbtCheck ;javafmtCheckAll ;+test:compile ;test ;unusedCompileDependenciesTest ;mimaReportBinaryIssues",
 )


### PR DESCRIPTION
Use .scalafmt.conf for the root project, because that's what scala steward assumes