### PR TITLE
Fix Scala 3 updating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.2, 2.12.16, 2.13.8]
+        scala: [3.1.3, 2.12.16, 2.13.8]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -154,12 +154,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.1.2)
+      - name: Download target directories (3.1.3)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.2
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3
 
-      - name: Inflate target directories (3.1.2)
+      - name: Inflate target directories (3.1.3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,4 @@
 updates.pin = [
   { groupId = "org.slf4j", artifactId = "slf4j-api", version = "1." },
-  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." },
-  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.0." }
+  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." }
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 
 val Scala212 = "2.12.16"
 val Scala213 = "2.13.8"
-val Scala3 = "3.1.2"
+val Scala3 = "3.1.3"
 val http4sVersion = "0.23.15"
 val munitCatsEffectVersion = "1.0.7"
 


### PR DESCRIPTION
On updating Scala 3 from 3.0.x to 3.1.x we forgot to update the Scala Steward config. So we are stuck on Scala 3.1.2 for a while. Let's fix this.