### PR TITLE
Fix `SSLStageSuite`

### DIFF
--- a/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSuite.scala
+++ b/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSuite.scala
@@ -63,7 +63,7 @@ class SSLStageSuite extends BlazeTestSuite {
 
     test(testSuitePrefix + " should split large buffers") {
       val (headEng, stageEng) = mkClientServerEngines
-      val s = "Fo" * (stageEng.getSession.getPacketBufferSize * 0.75).toInt
+      val s = "Fo" * (stageEng.getSession.getPacketBufferSize * 0.45).toInt
 
       /* The detection of splitting the buffer is seen by checking the write
        * output: if its flushing, the output should only be single buffers for
@@ -87,14 +87,16 @@ class SSLStageSuite extends BlazeTestSuite {
 
       head.sendInboundCommand(Connected)
 
-      assertFuture_(tail.startLoop()).flatMap(_ =>
-        assertFuture(
+      for {
+        _ <- tail.startLoop()
+        _ <- assertFuture(
           for {
             r <- Future(BufferTools.mkString(head.results))
             h <- Future(head.multipleWrite)
           } yield r -> h,
           s + s -> false
-        ))
+        )
+      } yield ()
     }
 
     test(testSuitePrefix + " should transcode multiple single byte buffers") {


### PR DESCRIPTION
_DISCLAIMER: this is a silly monkey-patching-like attempt to resolve https://github.com/http4s/blaze/issues/769_ 

That change might make this particular test nonsense, but I will try to share my insights about it.

## Prerequisites
### Let us introduce the following notation:

| _name_            	| _bytes_                                 	|
|-------------------	|-----------------------------------------	|
| **contentLength** 	| [s.getBytes.length](https://github.com/http4s/blaze/blob/series/0.23/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSuite.scala#L66)                       	|
| **packetSize**    	| [stageEng.getSession.getPacketBufferSize](https://github.com/http4s/blaze/blob/series/0.23/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSuite.scala#L66) 	|

### Test suite says:
```
/* The detection of splitting the buffer is seen by checking the write
 * output: if its flushing, the output should only be single buffers for
 * a small flush limits. This could break with changes to the SSLStage
 * algorithm
 */
```

### What is the `SSLSession#getPacketBufferSize`?
According to the [docs](hhttps://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/net/ssl/SSLSession.html#getPacketBufferSize()):

> Gets the current size of the largest SSL/TLS/DTLS packet that is expected when using this session.
An SSLEngine using this session may generate SSL/TLS/DTLS **packets of any size up to and including the value returned by this method**. All SSLEngine network buffers should be sized at least this large to avoid insufficient space problems when performing wrap and unwrap calls.


## So what?
When the `contentLength` gets closer or goes beyond the value of `packetSize` – we get a failed test. The default value of `packetSize` is equal to '16709' on the JDK 17. In that particular test, we set `SSLStage#maxWrite` to [100](https://github.com/http4s/blaze/blob/series/0.23/core/src/test/scala/org/http4s/blaze/pipeline/stages/SSLStageSuite.scala#L85). So, my hypothesis is if we adjust the value of `contentLegth` to be greater than `SSLStage#maxWrite` and less than `packetSize` we should preserve the sense of the test suite.

## Behind the scenes
Nonetheless, I have no idea why this test become broken. 🤷🏻 