### PR TITLE
cats-effect-3.5

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -211,7 +211,7 @@ private final class Http1Connection[F[_]](
           }
 
           val writeRequest: F[Boolean] = getChunkEncoder(req, mustClose, rr)
-            .write(rr, req.body)
+            .write(rr, req.body, someShutdownCancelToken)
             .onError {
               case EOF => F.delay(shutdownWithError(EOF))
               case t =>

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Support.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Support.scala
@@ -76,13 +76,17 @@ private final class Http1Support[F[_]](
     connectTimeout,
   )
 
+  /* This is an uncancelable operation, and it's the caller's
+   * responsibility to guarantee this connection gets closed.
+   */
   def makeClient(requestKey: RequestKey): F[BlazeConnection[F]] =
     getAddress(requestKey) match {
       case Right(a) =>
         fromFutureNoShift(
           executionContextConfig.getExecutionContext.flatMap(ec =>
             F.delay(buildPipeline(requestKey, a, ec))
-          )
+          ),
+          None,
         )
       case Left(t) => F.raiseError(t)
     }

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/DumpingWriter.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 object DumpingWriter {
   def dump(p: EntityBody[IO]): IO[Array[Byte]] = {
     val w = new DumpingWriter()
-    for (_ <- w.writeEntityBody(p)) yield w.toArray
+    for (_ <- w.writeEntityBody(p, None)) yield w.toArray
   }
 }
 

--- a/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
+++ b/blaze-core/src/test/scala/org/http4s/blazecore/util/Http1WriterSpec.scala
@@ -55,7 +55,7 @@ class Http1WriterSpec extends CatsEffectSuite with DispatcherIOFixture {
 
     for {
       _ <- IO.fromFuture(IO(w.writeHeaders(new StringWriter << "Content-Type: text/plain\r\n")))
-      _ <- w.writeEntityBody(p).attempt
+      _ <- w.writeEntityBody(p, None).attempt
       _ <- IO(head.stageShutdown())
       _ <- IO.fromFuture(IO(head.result))
     } yield new String(head.getBytes(), StandardCharsets.ISO_8859_1)
@@ -290,14 +290,14 @@ class Http1WriterSpec extends CatsEffectSuite with DispatcherIOFixture {
     val p = repeatEval(IO.pure[Byte](0.toByte)).take(300000)
 
     // The dumping writer is stack safe when using a trampolining EC
-    (new DumpingWriter).writeEntityBody(p).attempt.map(_.isRight).assert
+    (new DumpingWriter).writeEntityBody(p, None).attempt.map(_.isRight).assert
   }
 
   test("FlushingChunkWriter should Execute cleanup on a failing Http1Writer") {
     (for {
       clean <- Ref.of[IO, Boolean](false)
       p = chunk(messageBuffer).onFinalizeWeak(clean.set(true))
-      w <- new FailingWriter().writeEntityBody(p).attempt
+      w <- new FailingWriter().writeEntityBody(p, None).attempt
       c <- clean.get
     } yield w.isLeft && c).assert
   }
@@ -308,7 +308,7 @@ class Http1WriterSpec extends CatsEffectSuite with DispatcherIOFixture {
     (for {
       clean <- Ref.of[IO, Boolean](false)
       p = eval(IO.raiseError(Failed)).onFinalizeWeak(clean.set(true))
-      w <- new FailingWriter().writeEntityBody(p).attempt
+      w <- new FailingWriter().writeEntityBody(p, None).attempt
       c <- clean.get
     } yield w.isLeft && c).assert
   }

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http1ServerStage.scala
@@ -228,6 +228,9 @@ private[blaze] class Http1ServerStage[F[_]](
     }
   }
 
+  private[this] val someShutdownCancelToken: Option[F[Unit]] =
+    Some(F.delay(stageShutdown()))
+
   protected def renderResponse(
       req: Request[F],
       resp: Response[F],
@@ -294,7 +297,7 @@ private[blaze] class Http1ServerStage[F[_]](
 
     // TODO: pool shifting: https://github.com/http4s/http4s/blob/main/core/src/main/scala/org/http4s/internal/package.scala#L45
     val fa = bodyEncoder
-      .write(rr, resp.body)
+      .write(rr, resp.body, someShutdownCancelToken)
       .recover { case EOF => true }
       .attempt
       .flatMap {

--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,7 @@ lazy val blazeCore = Project("http4s-blaze-core", file("blaze-core"))
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-core" % http4sVersion,
+      "org.typelevel" %% "cats-effect-std" % "3.5.0-RC2",
       "org.typelevel" %% "munit-cats-effect" % munitCatsEffectVersion % Test,
       logbackClassic % Test,
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Dependencies._
 val Scala212 = "2.12.17"
 val Scala213 = "2.13.10"
 val Scala3 = "3.2.2"
-val http4sVersion = "0.23.18"
+val http4sVersion = "0.23.19-RC1"
 val munitCatsEffectVersion = "2.0.0-M3"
 
 ThisBuild / resolvers +=
@@ -136,7 +136,6 @@ lazy val blazeCore = Project("http4s-blaze-core", file("blaze-core"))
     tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet,
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-core" % http4sVersion,
-      "org.typelevel" %% "cats-effect-std" % "3.5.0-RC2",
       "org.typelevel" %% "munit-cats-effect" % munitCatsEffectVersion % Test,
       logbackClassic % Test,
     ),


### PR DESCRIPTION
The basic strategy is to shut down a stage if cancellation happens during an IO operation.  Cancellation probably happens because we're already shutting down the stage, but this makes sure.

Getting ahead of this.  See #772.