### PR TITLE
Upgrade to http4s-0.23.19

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -179,8 +179,6 @@ private final class Http1Connection[F[_]](
 
   override protected def contentComplete(): Boolean = parser.contentComplete()
 
-  private[this] val noopCancel = Some(F.unit)
-
   private def executeRequest(
       req: Request[F],
       cancellation: F[TimeoutException],
@@ -218,7 +216,7 @@ private final class Http1Connection[F[_]](
           val idleTimeoutF: F[TimeoutException] = idleTimeoutStage match {
             case Some(stage) =>
               F.async[TimeoutException] { cb =>
-                F.delay(stage.setTimeout(cb)).as(noopCancel)
+                F.delay(stage.setTimeout(cb)).as(Some(F.delay(stage.cancelTimeout())))
               }
             case None => F.never[TimeoutException]
           }

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -179,6 +179,8 @@ private final class Http1Connection[F[_]](
 
   override protected def contentComplete(): Boolean = parser.contentComplete()
 
+  private[this] val noopCancel = Some(F.unit)
+
   private def executeRequest(
       req: Request[F],
       cancellation: F[TimeoutException],
@@ -214,7 +216,10 @@ private final class Http1Connection[F[_]](
             }
 
           val idleTimeoutF: F[TimeoutException] = idleTimeoutStage match {
-            case Some(stage) => F.async_[TimeoutException](stage.setTimeout)
+            case Some(stage) =>
+              F.async[TimeoutException] { cb =>
+                F.delay(stage.setTimeout(cb)).as(noopCancel)
+              }
             case None => F.never[TimeoutException]
           }
 
@@ -254,15 +259,20 @@ private final class Http1Connection[F[_]](
     }
   }
 
+  private[this] val shutdownCancelToken = Some(F.delay(stageShutdown()))
+
   private def receiveResponse(
       closeOnFinish: Boolean,
       doesntHaveBody: Boolean,
       idleTimeoutS: F[Either[Throwable, Unit]],
       idleRead: Option[Future[ByteBuffer]],
   ): F[Response[F]] =
-    F.async_[Response[F]] { cb =>
-      val read = idleRead.getOrElse(channelRead())
-      handleRead(read, cb, closeOnFinish, doesntHaveBody, "Initial Read", idleTimeoutS)
+    F.async[Response[F]] { cb =>
+      F.delay {
+        val read = idleRead.getOrElse(channelRead())
+        handleRead(read, cb, closeOnFinish, doesntHaveBody, "Initial Read", idleTimeoutS)
+        shutdownCancelToken
+      }
     }
 
   // this method will get some data, and try to continue parsing using the implicit ec

--- a/blaze-client/src/main/scala/org/http4s/blaze/client/PoolManager.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/PoolManager.scala
@@ -206,7 +206,7 @@ private final class PoolManager[F[_], A <: Connection[F]](
   def borrow(key: RequestKey): F[NextConnection] =
     F.async { callback =>
       semaphore.permit
-        .use { _ =>
+        .surround {
           if (!isClosed) {
             def go(): F[Unit] =
               getConnectionFromQueue(key).flatMap {

--- a/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/Http1Stage.scala
@@ -197,6 +197,8 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
     // we are not finished and need more data.
     else streamingBody(buffer, eofCondition)
 
+  private[this] val shutdownCancelToken = Some(F.delay(stageShutdown()))
+
   // Streams the body off the wire
   private def streamingBody(
       buffer: ByteBuffer,
@@ -205,46 +207,48 @@ private[http4s] trait Http1Stage[F[_]] { self: TailStage[ByteBuffer] =>
     @volatile var currentBuffer = buffer
 
     // TODO: we need to work trailers into here somehow
-    val t = F.async_[Option[Chunk[Byte]]] { cb =>
-      if (!contentComplete()) {
-        def go(): Unit =
-          try {
-            val parseResult = doParseContent(currentBuffer)
-            logger.debug(s"Parse result: $parseResult, content complete: ${contentComplete()}")
-            parseResult match {
-              case Some(result) =>
-                cb(Either.right(Chunk.byteBuffer(result).some))
+    val t = F.async[Option[Chunk[Byte]]] { cb =>
+      F.delay {
+        if (!contentComplete()) {
+          def go(): Unit =
+            try {
+              val parseResult = doParseContent(currentBuffer)
+              logger.debug(s"Parse result: $parseResult, content complete: ${contentComplete()}")
+              parseResult match {
+                case Some(result) =>
+                  cb(Either.right(Chunk.byteBuffer(result).some))
 
-              case None if contentComplete() =>
-                cb(End)
+                case None if contentComplete() =>
+                  cb(End)
 
-              case None =>
-                channelRead().onComplete {
-                  case Success(b) =>
-                    currentBuffer = BufferTools.concatBuffers(currentBuffer, b)
-                    go()
+                case None =>
+                  channelRead().onComplete {
+                    case Success(b) =>
+                      currentBuffer = BufferTools.concatBuffers(currentBuffer, b)
+                      go()
 
-                  case Failure(Command.EOF) =>
-                    cb(eofCondition())
+                    case Failure(Command.EOF) =>
+                      cb(eofCondition())
 
-                  case Failure(t) =>
-                    logger.error(t)("Unexpected error reading body.")
-                    cb(Either.left(t))
-                }
+                    case Failure(t) =>
+                      logger.error(t)("Unexpected error reading body.")
+                      cb(Either.left(t))
+                  }
+              }
+            } catch {
+              case t: ParserException =>
+                fatalError(t, "Error parsing request body")
+                cb(Either.left(InvalidBodyException(t.getMessage())))
+
+              case t: Throwable =>
+                fatalError(t, "Error collecting body")
+                cb(Either.left(t))
             }
-          } catch {
-            case t: ParserException =>
-              fatalError(t, "Error parsing request body")
-              cb(Either.left(InvalidBodyException(t.getMessage())))
-
-            case t: Throwable =>
-              fatalError(t, "Error collecting body")
-              cb(Either.left(t))
-          }
-        go()
-      } else cb(End)
+          go()
+        } else cb(End)
+        shutdownCancelToken
+      }
     }
-
     (repeatEval(t).unNoneTerminate.flatMap(chunk(_)), () => drainBody(currentBuffer))
   }
 

--- a/blaze-core/src/main/scala/org/http4s/blazecore/util/package.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/util/package.scala
@@ -42,6 +42,8 @@ package object util extends ParasiticExecutionContextCompat {
         case Some(value) =>
           F.fromTry(value)
         case None =>
+          // Scala futures are uncancelable.  There's not much we can
+          // do here other than async_.
           F.async_ { cb =>
             future.onComplete {
               case Success(a) => cb(Right(a))

--- a/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
+++ b/blaze-core/src/main/scala/org/http4s/blazecore/websocket/Http4sWSStage.scala
@@ -66,23 +66,29 @@ private[http4s] class Http4sWSStage[F[_]](
 
   def snkFun(frame: WebSocketFrame): F[Unit] = isClosed.ifM(F.unit, evalFrame(frame))
 
+  private[this] val shutdownCancelToken = Some(F.delay(stageShutdown()))
+
   private[this] def writeFrame(frame: WebSocketFrame, ec: ExecutionContext): F[Unit] =
-    writeSemaphore.permit.use { _ =>
-      F.async_[Unit] { cb =>
-        channelWrite(frame).onComplete {
-          case Success(res) => cb(Right(res))
-          case Failure(t) => cb(Left(t))
-        }(ec)
-      }
-    }
+    writeSemaphore.permit.surround(
+      F.async[Unit](cb =>
+        F.delay(
+          channelWrite(frame).onComplete {
+            case Success(res) => cb(Right(res))
+            case Failure(t) => cb(Left(t))
+          }(ec)
+        ).as(shutdownCancelToken)
+      )
+    )
 
   private[this] def readFrameTrampoline: F[WebSocketFrame] =
-    F.async_[WebSocketFrame] { cb =>
-      channelRead().onComplete {
-        case Success(ws) => cb(Right(ws))
-        case Failure(exception) => cb(Left(exception))
-      }(trampoline)
-    }
+    F.async[WebSocketFrame](cb =>
+      F.delay(
+        channelRead().onComplete {
+          case Success(ws) => cb(Right(ws))
+          case Failure(exception) => cb(Left(exception))
+        }(trampoline)
+      ).as(shutdownCancelToken)
+    )
 
   /** Read from our websocket.
     *

--- a/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
+++ b/blaze-server/src/main/scala/org/http4s/blaze/server/Http2NodeStage.scala
@@ -105,6 +105,8 @@ private class Http2NodeStage[F[_]](
         closePipeline(Some(e))
     }
 
+  private[this] val shutdownStageToken = Some(F.delay(stageShutdown()))
+
   /** collect the body: a maxlen < 0 is interpreted as undefined */
   private def getBody(maxlen: Long): EntityBody[F] = {
     var complete = false
@@ -156,7 +158,7 @@ private class Http2NodeStage[F[_]](
               closePipeline(Some(e))
           }
 
-        None
+        shutdownStageToken
       }
     }
 

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -537,7 +537,7 @@ class Http1ServerStageSpec extends CatsEffectSuite {
     }
   }
 
-  fixture.test("Http1ServerStage: routes should cancels on stage shutdown".flaky) { tw =>
+  fixture.test("Http1ServerStage: routes should cancel on stage shutdown".flaky) { tw =>
     Deferred[IO, Unit]
       .flatMap { canceled =>
         Deferred[IO, Unit].flatMap { gate =>

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Dependencies._
 val Scala212 = "2.12.17"
 val Scala213 = "2.13.10"
 val Scala3 = "3.2.2"
-val http4sVersion = "0.23.18"
+val http4sVersion = "0.23.19"
 val munitCatsEffectVersion = "2.0.0-M3"
 
 ThisBuild / resolvers +=

--- a/examples/src/main/scala/com/example/http4s/blaze/demo/server/Module.scala
+++ b/examples/src/main/scala/com/example/http4s/blaze/demo/server/Module.scala
@@ -24,6 +24,8 @@ import com.example.http4s.blaze.demo.server.endpoints.auth.BasicAuthHttpEndpoint
 import com.example.http4s.blaze.demo.server.endpoints.auth.GitHubHttpEndpoint
 import com.example.http4s.blaze.demo.server.service.FileService
 import com.example.http4s.blaze.demo.server.service.GitHubService
+import fs2.compression.Compression
+import fs2.io.file.Files
 import org.http4s.HttpRoutes
 import org.http4s.client.Client
 import org.http4s.server.HttpMiddleware
@@ -34,7 +36,7 @@ import org.http4s.server.middleware.Timeout
 
 import scala.concurrent.duration._
 
-class Module[F[_]: Async](client: Client[F]) {
+class Module[F[_]: Async: Compression: Files](client: Client[F]) {
   private val fileService = new FileService[F]
 
   private val gitHubService = new GitHubService[F](client)

--- a/examples/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
+++ b/examples/src/main/scala/com/example/http4s/blaze/demo/server/Server.scala
@@ -18,6 +18,8 @@ package com.example.http4s.blaze.demo.server
 
 import cats.effect._
 import fs2.Stream
+import fs2.compression.Compression
+import fs2.io.file.Files
 import org.http4s.HttpApp
 import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.blaze.server.BlazeServerBuilder
@@ -37,7 +39,7 @@ object HttpServer {
       "/" -> ctx.httpServices
     ).orNotFound
 
-  def stream[F[_]: Async]: Stream[F, ExitCode] =
+  def stream[F[_]: Async: Compression: Files]: Stream[F, ExitCode] =
     for {
       client <- BlazeClientBuilder[F].stream
       ctx <- Stream(new Module[F](client))

--- a/examples/src/main/scala/com/example/http4s/blaze/demo/server/service/FileService.scala
+++ b/examples/src/main/scala/com/example/http4s/blaze/demo/server/service/FileService.scala
@@ -26,7 +26,7 @@ import org.http4s.multipart.Part
 import java.io.File
 import java.nio.file.Paths
 
-class FileService[F[_]](implicit F: Async[F], S: StreamUtils[F]) {
+class FileService[F[_]](implicit F: Async[F], S: StreamUtils[F], files: Files[F]) {
   def homeDirectories(depth: Option[Int]): Stream[F, String] =
     S.env("HOME").flatMap { maybePath =>
       val ifEmpty = S.error("HOME environment variable not found!")


### PR DESCRIPTION
This is a fairly urgent fix after cats-effect-3.5.0.

* Fixes deprecation warnings from fs2-3.7.0
* Addresses changes to semantics of `F.async_`.  The general strategy is to shutdown the stage.  Many of the changes are whitespace.