### PR TITLE
Implement Connection persistence per RFC 9112, Section 9.3

### DIFF
--- a/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
+++ b/blaze-client/src/main/scala/org/http4s/blaze/client/Http1Connection.scala
@@ -200,10 +200,9 @@ private final class Http1Connection[F[_]](
           if (userAgent.nonEmpty && !req.headers.contains[`User-Agent`])
             rr << userAgent.get << "\r\n"
 
-          val mustClose: Boolean = req.headers.get[HConnection] match {
-            case Some(conn) => checkCloseConnection(conn, rr)
-            case None => getHttpMinor(req) == 0
-          }
+          val mustClose: Boolean = checkRequestCloseConnection(req)
+          if (mustClose)
+            rr << "Connection: close\r\n"
 
           val writeRequest: F[Boolean] = getChunkEncoder(req, mustClose, rr)
             .write(rr, req.entity)


### PR DESCRIPTION
We are aggressively closing connections in the presence of `Connection` headers composed exclusively of options other than `keep-alive` or `close`.  This is contrary to [the RFC](https://datatracker.ietf.org/doc/html/rfc9112#section-9.3)

